### PR TITLE
Add pytest regression tests

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 torch>=1.13
 numpy
 PyYAML
+pytest

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,7 @@
+import os
+import sys
+
+# Add repository root to PYTHONPATH for tests
+ROOT_DIR = os.path.dirname(os.path.dirname(__file__))
+if ROOT_DIR not in sys.path:
+    sys.path.insert(0, ROOT_DIR)

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -1,0 +1,13 @@
+import torch
+from crosslearner.datasets.toy import get_toy_dataloader
+
+
+def test_get_toy_dataloader_shapes():
+    loader, (mu0, mu1) = get_toy_dataloader(batch_size=4, n=8, p=3)
+    assert len(loader.dataset) == 8
+    X, T, Y = next(iter(loader))
+    assert X.shape == (4, 3)
+    assert T.shape == (4, 1)
+    assert Y.shape == (4, 1)
+    assert mu0.shape == (8, 1)
+    assert mu1.shape == (8, 1)

--- a/tests/test_grl.py
+++ b/tests/test_grl.py
@@ -1,0 +1,9 @@
+import torch
+from crosslearner.training.grl import grad_reverse
+
+
+def test_grad_reverse_backward():
+    x = torch.tensor([1.0, 2.0, 3.0], requires_grad=True)
+    y = grad_reverse(x, lambd=1.0)
+    y.sum().backward()
+    assert torch.allclose(x.grad, torch.tensor([-1.0, -1.0, -1.0]))

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -1,0 +1,10 @@
+import torch
+from crosslearner.evaluation.metrics import pehe
+
+
+def test_pehe():
+    tau_hat = torch.tensor([0.0, 1.0])
+    tau_true = torch.tensor([0.0, 0.0])
+    result = pehe(tau_hat, tau_true)
+    expected = (0.5) ** 0.5
+    assert abs(result - expected) < 1e-6

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -1,0 +1,12 @@
+import torch
+from crosslearner.models.acx import ACX
+
+
+def test_acx_forward_shapes():
+    model = ACX(p=5)
+    X = torch.randn(2, 5)
+    h, m0, m1, tau = model(X)
+    assert h.shape == (2, 64)
+    assert m0.shape == (2, 1)
+    assert m1.shape == (2, 1)
+    assert tau.shape == (2, 1)

--- a/tests/test_training.py
+++ b/tests/test_training.py
@@ -1,0 +1,16 @@
+import torch
+from crosslearner.datasets.toy import get_toy_dataloader
+from crosslearner.training.train_acx import train_acx
+from crosslearner.evaluation.evaluate import evaluate
+
+
+def test_train_acx_short():
+    torch.manual_seed(0)
+    loader, (mu0, mu1) = get_toy_dataloader(batch_size=16, n=64, p=4)
+    model = train_acx(loader, p=4, device='cpu', epochs=2)
+    X = torch.cat([b[0] for b in loader])
+    mu0_all = mu0
+    mu1_all = mu1
+    metric = evaluate(model, X, mu0_all, mu1_all)
+    assert isinstance(metric, float)
+    assert metric >= 0.0


### PR DESCRIPTION
## Summary
- add a `pytest` test suite for datasets, models, training and utilities
- support tests by installing `pytest` in `requirements.txt`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684d5953e2bc8324b39db73142c8c53d