### PR TITLE
Add benchmark suite with complex synthetic data and external dataset option

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,16 @@ python train.py
 
 The script trains an AC‑X model on a synthetic dataset and prints the final \sqrt{PEHE}.
 
+## Benchmarking
+
+To run a small benchmark across multiple datasets use:
+
+```bash
+python -m crosslearner.benchmarks.run_benchmarks toy --replicates 3
+```
+
+Replace `toy` with `complex` for a harder synthetic task or `iris` to automatically download a tiny external dataset and evaluate on it.
+
 ## Repository Layout
 
 - `crosslearner/models/` – model definitions including `ACX`.

--- a/crosslearner/__init__.py
+++ b/crosslearner/__init__.py
@@ -1,0 +1,5 @@
+from .datasets import get_toy_dataloader, get_complex_dataloader
+from .training.train_acx import train_acx
+from .evaluation.evaluate import evaluate
+
+__all__ = ["get_toy_dataloader", "get_complex_dataloader", "train_acx", "evaluate"]

--- a/crosslearner/benchmarks/__init__.py
+++ b/crosslearner/benchmarks/__init__.py
@@ -1,0 +1,1 @@
+from .run_benchmarks import run

--- a/crosslearner/benchmarks/run_benchmarks.py
+++ b/crosslearner/benchmarks/run_benchmarks.py
@@ -1,0 +1,81 @@
+import argparse
+import os
+import urllib.request
+from typing import List
+
+import torch
+from torch.utils.data import DataLoader, TensorDataset
+
+from crosslearner.datasets.toy import get_toy_dataloader
+from crosslearner.datasets.complex import get_complex_dataloader
+from crosslearner.training.train_acx import train_acx
+from crosslearner.evaluation.evaluate import evaluate
+
+
+def load_external_iris(batch_size: int = 256, seed: int | None = None):
+    """Download the Iris dataset and create a synthetic causal task."""
+    url = (
+        "https://raw.githubusercontent.com/scikit-learn/"
+        "scikit-learn/main/sklearn/datasets/data/iris.csv"
+    )
+    fname = os.path.join(os.path.dirname(__file__), "iris.csv")
+    if not os.path.exists(fname):
+        urllib.request.urlretrieve(url, fname)
+    data = []
+    with open(fname) as f:
+        next(f)  # header
+        for line in f:
+            parts = line.strip().split(",")
+            data.append([float(p) for p in parts[:4]])
+    X = torch.tensor(data)
+    if seed is not None:
+        gen = torch.Generator().manual_seed(seed)
+    else:
+        gen = None
+    T_prob = torch.sigmoid(X[:, 0] / 2)
+    T = torch.bernoulli(T_prob, generator=gen).float().unsqueeze(-1)
+    mu0 = X.sum(1, keepdim=True) / 10
+    mu1 = mu0 + torch.sin(X[:, 1:3].sum(1, keepdim=True))
+    Y = torch.where(T.bool(), mu1, mu0) + 0.1 * torch.randn(X.size(0), 1, generator=gen)
+    loader = DataLoader(TensorDataset(X, T, Y), batch_size=batch_size, shuffle=True)
+    return loader, (mu0, mu1)
+
+
+def run(dataset: str, replicates: int = 3, epochs: int = 30) -> List[float]:
+    """Run the benchmark for the given dataset and return list of PEHE values."""
+    results = []
+    for seed in range(replicates):
+        if dataset == "toy":
+            loader, (mu0, mu1) = get_toy_dataloader()
+            p = 10
+        elif dataset == "complex":
+            loader, (mu0, mu1) = get_complex_dataloader(seed=seed)
+            p = 20
+        elif dataset == "iris":
+            loader, (mu0, mu1) = load_external_iris(seed=seed)
+            p = 4
+        else:
+            raise ValueError(f"Unknown dataset {dataset}")
+        model = train_acx(loader, p=p, epochs=epochs)
+        X = torch.cat([b[0] for b in loader])
+        mu0_all = mu0
+        mu1_all = mu1
+        pehe_val = evaluate(model, X, mu0_all, mu1_all)
+        print(f"replicate {seed}: sqrt PEHE {pehe_val:.3f}")
+        results.append(pehe_val)
+    mean_pehe = sum(results) / len(results)
+    print(f"mean sqrt PEHE: {mean_pehe:.3f}")
+    return results
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Run CrossLearner benchmarks")
+    parser.add_argument("dataset", choices=["toy", "complex", "iris"], help="dataset to benchmark")
+    parser.add_argument("--replicates", type=int, default=3)
+    parser.add_argument("--epochs", type=int, default=30)
+    args = parser.parse_args()
+    run(args.dataset, args.replicates, args.epochs)
+
+
+if __name__ == "__main__":
+    main()

--- a/crosslearner/datasets/__init__.py
+++ b/crosslearner/datasets/__init__.py
@@ -1,0 +1,4 @@
+from .toy import get_toy_dataloader
+from .complex import get_complex_dataloader
+
+__all__ = ["get_toy_dataloader", "get_complex_dataloader"]

--- a/crosslearner/datasets/complex.py
+++ b/crosslearner/datasets/complex.py
@@ -1,0 +1,21 @@
+import torch
+from torch.utils.data import TensorDataset, DataLoader
+
+
+def get_complex_dataloader(batch_size: int = 256, n: int = 8000, p: int = 20, seed: int | None = None):
+    """Return DataLoader with a more complex synthetic dataset."""
+    if seed is not None:
+        gen = torch.Generator().manual_seed(seed)
+    else:
+        gen = None
+    X = torch.randn(n, p, generator=gen)
+    logit = (X[:, :3].prod(-1) + torch.sin(X[:, 3]) - X[:, 4] ** 2)
+    pi = torch.sigmoid(logit)
+    T = torch.bernoulli(pi, generator=gen).float()
+    mu0 = X[:, 0] + torch.cos(X[:, 1]) + 0.5 * (X[:, 2] ** 2)
+    mu1 = mu0 + torch.tanh(X[:, 3] + X[:, 4]) + X[:, 5]
+    Y = torch.where(T.bool(), mu1, mu0) + 0.5 * torch.randn(n, generator=gen)
+    return DataLoader(TensorDataset(X, T.unsqueeze(-1), Y.unsqueeze(-1)), batch_size=batch_size, shuffle=True), (
+        mu0.unsqueeze(-1),
+        mu1.unsqueeze(-1),
+    )

--- a/tests/test_benchmark.py
+++ b/tests/test_benchmark.py
@@ -1,0 +1,7 @@
+from crosslearner.benchmarks.run_benchmarks import run
+
+
+def test_run_benchmark_toy_short():
+    results = run('toy', replicates=1, epochs=1)
+    assert len(results) == 1
+    assert results[0] >= 0.0

--- a/tests/test_complex_dataset.py
+++ b/tests/test_complex_dataset.py
@@ -1,0 +1,12 @@
+from crosslearner.datasets.complex import get_complex_dataloader
+
+
+def test_get_complex_dataloader_shapes():
+    loader, (mu0, mu1) = get_complex_dataloader(batch_size=4, n=8, p=6, seed=0)
+    assert len(loader.dataset) == 8
+    X, T, Y = next(iter(loader))
+    assert X.shape == (4, 6)
+    assert T.shape == (4, 1)
+    assert Y.shape == (4, 1)
+    assert mu0.shape == (8, 1)
+    assert mu1.shape == (8, 1)


### PR DESCRIPTION
## Summary
- add complex synthetic dataset
- add benchmark runner that can optionally download the iris dataset
- expose new modules and document the benchmark CLI
- test complex dataset and benchmark runner

## Testing
- `python -m pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_684d5de87b388324b8e692e38704bfb0