### PR TITLE
Add visualisation utilities for model diagnostics

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,3 +41,11 @@ Replace `toy` with `complex` for a harder synthetic task or `iris` to automatica
 The training code exposes toggles for Wasserstein loss, spectral normalisation, feature matching, instance noise, gradient reversal and two‑time‑scale update rule (TTUR) as described in `Prompt.txt`.
 
 Use the config file as a starting point for your own experiments on IHDP, ACIC or other datasets.
+
+## Visualisation
+
+To diagnose training and model fit visually, pass the `History` returned by
+`train_acx` to `crosslearner.visualization.plot_losses` to plot generator and
+discriminator losses over time.  The module also provides
+`crosslearner.visualization.scatter_tau` for a scatter plot of predicted versus
+true treatment effects.

--- a/crosslearner/__init__.py
+++ b/crosslearner/__init__.py
@@ -2,6 +2,7 @@ from .datasets import get_toy_dataloader, get_complex_dataloader
 from .training.train_acx import train_acx
 from .training.history import EpochStats, History
 from .evaluation.evaluate import evaluate
+from .visualization import plot_losses, scatter_tau
 
 __all__ = [
     "get_toy_dataloader",
@@ -10,4 +11,6 @@ __all__ = [
     "EpochStats",
     "History",
     "evaluate",
+    "plot_losses",
+    "scatter_tau",
 ]

--- a/crosslearner/visualization.py
+++ b/crosslearner/visualization.py
@@ -1,0 +1,35 @@
+import torch
+from matplotlib import pyplot as plt
+from typing import Iterable
+
+from .models.acx import ACX
+from .training.history import History
+
+
+def plot_losses(history: History):
+    """Return a matplotlib Figure showing loss curves."""
+    epochs = [h.epoch for h in history]
+    fig, ax = plt.subplots()
+    ax.plot(epochs, [h.loss_d for h in history], label="discriminator")
+    ax.plot(epochs, [h.loss_g for h in history], label="generator")
+    ax.set_xlabel("epoch")
+    ax.set_ylabel("loss")
+    ax.legend()
+    fig.tight_layout()
+    return fig
+
+
+def scatter_tau(model: ACX, X: torch.Tensor, mu0: torch.Tensor, mu1: torch.Tensor):
+    """Return a Figure comparing true and predicted treatment effects."""
+    model.eval()
+    with torch.no_grad():
+        _, _, _, tau_hat = model(X)
+    tau_true = mu1 - mu0
+    fig, ax = plt.subplots()
+    ax.scatter(tau_true.cpu(), tau_hat.cpu(), alpha=0.5)
+    maxv = float(torch.max(torch.abs(torch.cat([tau_true, tau_hat]))))
+    ax.plot([-maxv, maxv], [-maxv, maxv], "r--", linewidth=1)
+    ax.set_xlabel("true tau")
+    ax.set_ylabel("predicted tau")
+    fig.tight_layout()
+    return fig

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ torch>=1.13
 numpy
 PyYAML
 pytest
+matplotlib

--- a/tests/test_visualization.py
+++ b/tests/test_visualization.py
@@ -1,0 +1,24 @@
+import torch
+import matplotlib
+matplotlib.use('Agg')
+
+from crosslearner.visualization import plot_losses, scatter_tau
+from crosslearner.training.history import EpochStats
+from crosslearner.models.acx import ACX
+
+
+def test_plot_losses_returns_figure():
+    hist = [EpochStats(epoch=0, loss_d=1.0, loss_g=2.0, loss_y=0.0, loss_cons=0.0, loss_adv=0.0)]
+    fig = plot_losses(hist)
+    assert fig is not None
+    matplotlib.pyplot.close(fig)
+
+
+def test_scatter_tau_returns_figure():
+    model = ACX(p=3)
+    X = torch.randn(4, 3)
+    mu0 = torch.zeros(4, 1)
+    mu1 = torch.ones(4, 1)
+    fig = scatter_tau(model, X, mu0, mu1)
+    assert fig is not None
+    matplotlib.pyplot.close(fig)


### PR DESCRIPTION
## Summary
- visualize ACX training losses and effect predictions
- export plotting helpers in library namespace
- document plotting helpers in README
- require matplotlib
- test plotting helpers

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684d6efb7ab48324bd01324ed24236db