### PR TITLE
Add IHDP dataset loader and baseline learners

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,10 +25,10 @@ discriminator losses to make experiment tracking easier.
 To run a small benchmark across multiple datasets use:
 
 ```bash
-python -m crosslearner.benchmarks.run_benchmarks toy --replicates 3
+python -m crosslearner.benchmarks.run_benchmarks all --replicates 1 --epochs 1
 ```
 
-Replace `toy` with `complex` for a harder synthetic task or `iris` to automatically download a tiny external dataset and evaluate on it.
+This downloads the IHDP and Jobs datasets and prints the mean `sqrt(PEHE)` for each available task.
 
 ## Repository Layout
 

--- a/crosslearner/datasets/__init__.py
+++ b/crosslearner/datasets/__init__.py
@@ -1,4 +1,11 @@
 from .toy import get_toy_dataloader
 from .complex import get_complex_dataloader
+from .ihdp import get_ihdp_dataloader
+from .jobs import get_jobs_dataloader
 
-__all__ = ["get_toy_dataloader", "get_complex_dataloader"]
+__all__ = [
+    "get_toy_dataloader",
+    "get_complex_dataloader",
+    "get_ihdp_dataloader",
+    "get_jobs_dataloader",
+]

--- a/crosslearner/datasets/ihdp.py
+++ b/crosslearner/datasets/ihdp.py
@@ -1,0 +1,45 @@
+import os
+import urllib.request
+from typing import Tuple
+
+import numpy as np
+import torch
+from torch.utils.data import DataLoader, TensorDataset
+
+URL_TRAIN = "https://www.fredjo.com/files/ihdp_npci_1-100.train.npz"
+URL_TEST = "https://www.fredjo.com/files/ihdp_npci_1-100.test.npz"
+
+
+def _download(url: str, path: str) -> str:
+    if not os.path.exists(path):
+        urllib.request.urlretrieve(url, path)
+    return path
+
+
+def get_ihdp_dataloader(
+    seed: int = 0, batch_size: int = 256, *, data_dir: str | None = None
+) -> Tuple[DataLoader, Tuple[torch.Tensor, torch.Tensor]]:
+    """Return IHDP dataloader for the given replication index."""
+    data_dir = data_dir or os.path.join(os.path.dirname(__file__), "_data")
+    os.makedirs(data_dir, exist_ok=True)
+    f_train = _download(URL_TRAIN, os.path.join(data_dir, "ihdp_train.npz"))
+    f_test = _download(URL_TEST, os.path.join(data_dir, "ihdp_test.npz"))
+
+    train = np.load(f_train)
+    test = np.load(f_test)
+    X = np.concatenate([train["x"][:, :, seed], test["x"][:, :, seed]], axis=0)
+    T = np.concatenate([train["t"][:, seed], test["t"][:, seed]], axis=0)
+    Y = np.concatenate([train["yf"][:, seed], test["yf"][:, seed]], axis=0)
+    mu0 = np.concatenate([train["mu0"][:, seed], test["mu0"][:, seed]], axis=0)
+    mu1 = np.concatenate([train["mu1"][:, seed], test["mu1"][:, seed]], axis=0)
+
+    dset = TensorDataset(
+        torch.tensor(X, dtype=torch.float32),
+        torch.tensor(T, dtype=torch.float32).unsqueeze(-1),
+        torch.tensor(Y, dtype=torch.float32).unsqueeze(-1),
+    )
+    loader = DataLoader(dset, batch_size=batch_size, shuffle=True)
+    return loader, (
+        torch.tensor(mu0, dtype=torch.float32).unsqueeze(-1),
+        torch.tensor(mu1, dtype=torch.float32).unsqueeze(-1),
+    )

--- a/crosslearner/datasets/jobs.py
+++ b/crosslearner/datasets/jobs.py
@@ -1,0 +1,15 @@
+import torch
+from torch.utils.data import DataLoader, TensorDataset
+from causaldata import nsw_mixtape
+
+
+def get_jobs_dataloader(batch_size: int = 256):
+    """Return DataLoader for the Jobs training dataset."""
+    df = nsw_mixtape.load_pandas().data
+    y = torch.tensor(df["re78"].values, dtype=torch.float32).unsqueeze(-1)
+    t = torch.tensor(df["treat"].values, dtype=torch.float32).unsqueeze(-1)
+    x = torch.tensor(
+        df.drop(columns=["re78", "treat", "data_id"]).values, dtype=torch.float32
+    )
+    loader = DataLoader(TensorDataset(x, t, y), batch_size=batch_size, shuffle=True)
+    return loader, (None, None)

--- a/crosslearner/models/baselines/__init__.py
+++ b/crosslearner/models/baselines/__init__.py
@@ -1,0 +1,5 @@
+from .slearner import SLearner
+from .tlearner import TLearner
+from .xlearner import XLearner
+
+__all__ = ["SLearner", "TLearner", "XLearner"]

--- a/crosslearner/models/baselines/slearner.py
+++ b/crosslearner/models/baselines/slearner.py
@@ -1,0 +1,21 @@
+from typing import Tuple
+import numpy as np
+import torch
+from sklearn.neural_network import MLPRegressor
+
+
+class SLearner:
+    def __init__(self, p: int):
+        self.model = MLPRegressor(hidden_layer_sizes=(64, 64), max_iter=100)
+        self.p = p
+
+    def fit(self, X: np.ndarray, T: np.ndarray, Y: np.ndarray):
+        XT = np.concatenate([X, T], axis=1)
+        self.model.fit(XT, Y.ravel())
+
+    def predict_tau(self, X: np.ndarray) -> torch.Tensor:
+        X1 = np.concatenate([X, np.ones((X.shape[0], 1))], axis=1)
+        X0 = np.concatenate([X, np.zeros((X.shape[0], 1))], axis=1)
+        mu1 = self.model.predict(X1)
+        mu0 = self.model.predict(X0)
+        return torch.tensor(mu1 - mu0, dtype=torch.float32)

--- a/crosslearner/models/baselines/tlearner.py
+++ b/crosslearner/models/baselines/tlearner.py
@@ -1,0 +1,25 @@
+import numpy as np
+import torch
+from sklearn.neural_network import MLPRegressor
+
+
+class TLearner:
+    def __init__(self, p: int):
+        self.model_t = MLPRegressor(hidden_layer_sizes=(64, 64), max_iter=100)
+        self.model_c = MLPRegressor(hidden_layer_sizes=(64, 64), max_iter=100)
+        self.p = p
+
+    def fit(self, X: np.ndarray, T: np.ndarray, Y: np.ndarray):
+        Xt = X[T.squeeze() == 1]
+        Yt = Y[T.squeeze() == 1]
+        Xc = X[T.squeeze() == 0]
+        Yc = Y[T.squeeze() == 0]
+        if len(Xt):
+            self.model_t.fit(Xt, Yt.ravel())
+        if len(Xc):
+            self.model_c.fit(Xc, Yc.ravel())
+
+    def predict_tau(self, X: np.ndarray) -> torch.Tensor:
+        mu1 = self.model_t.predict(X)
+        mu0 = self.model_c.predict(X)
+        return torch.tensor(mu1 - mu0, dtype=torch.float32)

--- a/crosslearner/models/baselines/xlearner.py
+++ b/crosslearner/models/baselines/xlearner.py
@@ -1,0 +1,35 @@
+import numpy as np
+import torch
+from sklearn.neural_network import MLPRegressor
+
+
+class XLearner:
+    def __init__(self, p: int):
+        self.t = TLearner(p)
+        self.model_tau_t = MLPRegressor(hidden_layer_sizes=(64, 64), max_iter=100)
+        self.model_tau_c = MLPRegressor(hidden_layer_sizes=(64, 64), max_iter=100)
+        self.p = p
+
+    def fit(self, X: np.ndarray, T: np.ndarray, Y: np.ndarray):
+        self.t.fit(X, T, Y)
+        Xt = X[T.squeeze() == 1]
+        Yt = Y[T.squeeze() == 1]
+        Xc = X[T.squeeze() == 0]
+        Yc = Y[T.squeeze() == 0]
+        mu0_t = self.t.model_c.predict(Xt) if len(Xt) else np.zeros(len(Xt))
+        d1 = Yt.ravel() - mu0_t
+        mu1_c = self.t.model_t.predict(Xc) if len(Xc) else np.zeros(len(Xc))
+        d0 = mu1_c - Yc.ravel()
+        if len(Xt):
+            self.model_tau_t.fit(Xt, d1)
+        if len(Xc):
+            self.model_tau_c.fit(Xc, d0)
+        self.prop = T.mean()
+
+    def predict_tau(self, X: np.ndarray) -> torch.Tensor:
+        tau_t = self.model_tau_t.predict(X)
+        tau_c = self.model_tau_c.predict(X)
+        return torch.tensor((1 - self.prop) * tau_t + self.prop * tau_c, dtype=torch.float32)
+
+
+from .tlearner import TLearner


### PR DESCRIPTION
## Summary
- add IHDP and Jobs dataset loaders
- expose new loaders from `datasets` package
- add simple S-, T-, and X-learner baselines
- extend benchmark script to support IHDP/Jobs and an `all` option
- document running the benchmark

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684de7a179b88324a1abba452bbac913