### PR TITLE
Add TensorBoard logging and early-stop features

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,8 @@ python train.py
 
 The script trains an AC‑X model on a synthetic dataset and prints the final \sqrt{PEHE}.
 The `train_acx` function also supports returning a full history of generator and
-discriminator losses to make experiment tracking easier.
+discriminator losses to make experiment tracking easier. Optionally pass a
+TensorBoard log directory to write these metrics for live dashboards.
 
 ## Benchmarking
 
@@ -38,7 +39,7 @@ This downloads the IHDP and Jobs datasets and prints the mean `sqrt(PEHE)` for e
 - `crosslearner/evaluation/` – metrics such as PEHE.
 - `crosslearner/configs/` – YAML configs with hyper‑parameters.
 
-The training code exposes toggles for Wasserstein loss, spectral normalisation, feature matching, instance noise, gradient reversal and two‑time‑scale update rule (TTUR) as described in `Prompt.txt`.
+The training code exposes toggles for Wasserstein loss (with gradient penalty or optional weight clipping), spectral normalisation, feature matching, instance noise, gradient reversal and two‑time‑scale update rule (TTUR). Early stopping on validation \sqrt{PEHE} is also available.
 
 Use the config file as a starting point for your own experiments on IHDP, ACIC or other datasets.
 

--- a/crosslearner/configs/default.yaml
+++ b/crosslearner/configs/default.yaml
@@ -16,3 +16,6 @@ ttur: false
 lambda_gp: 10.0
 eta_fm: 5.0
 grl_weight: 1.0
+tensorboard_logdir: null
+weight_clip: null
+patience: 0

--- a/crosslearner/training/history.py
+++ b/crosslearner/training/history.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from typing import List
+from typing import List, Optional
 
 @dataclass
 class EpochStats:
@@ -10,5 +10,6 @@ class EpochStats:
     loss_y: float
     loss_cons: float
     loss_adv: float
+    val_pehe: Optional[float] = None
 
 History = List[EpochStats]

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ pytest
 matplotlib
 scikit-learn
 causaldata
+tensorboard

--- a/tests/test_training.py
+++ b/tests/test_training.py
@@ -14,3 +14,35 @@ def test_train_acx_short():
     metric = evaluate(model, X, mu0_all, mu1_all)
     assert isinstance(metric, float)
     assert metric >= 0.0
+
+
+def test_tensorboard_logging(tmp_path):
+    loader, _ = get_toy_dataloader(batch_size=16, n=32, p=4)
+    logdir = tmp_path / "tb"
+    train_acx(loader, p=4, device="cpu", epochs=1, tensorboard_logdir=str(logdir))
+    assert any(logdir.iterdir())
+
+
+def test_weight_clipping():
+    torch.manual_seed(0)
+    loader, _ = get_toy_dataloader(batch_size=16, n=64, p=4)
+    model = train_acx(loader, p=4, device="cpu", epochs=1, weight_clip=0.01)
+    for p in model.disc.parameters():
+        assert p.data.abs().max() <= 0.011
+
+
+def test_early_stopping():
+    torch.manual_seed(0)
+    loader, (mu0, mu1) = get_toy_dataloader(batch_size=16, n=64, p=4)
+    X = torch.cat([b[0] for b in loader])
+    val_data = (X, mu0, mu1)
+    _, history = train_acx(
+        loader,
+        p=4,
+        device="cpu",
+        epochs=5,
+        val_data=val_data,
+        patience=1,
+        return_history=True,
+    )
+    assert len(history) <= 5


### PR DESCRIPTION
## Summary
- log training metrics to TensorBoard when a logdir is provided
- support gradient penalty, optional weight clipping, and early stopping
- add new parameters in default config
- extend training history to include validation PEHE
- test TensorBoard, weight clipping and early stopping

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684def5f2660832485b0dee784a4b0a8