### PR TITLE
Add GAN invariants tests & expand CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,8 +9,10 @@ jobs:
   test:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
-        python-version: ["3.10", "3.11"]
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
+        cuda: ["cpu", "cu118"]
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
@@ -20,5 +22,11 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements.txt
+          pip install black ruff
+          pip install torch --extra-index-url https://download.pytorch.org/whl/${{ matrix.cuda }}
+      - name: Lint
+        run: |
+          ruff check .
+          black --check .
       - name: Run tests
         run: pytest -q

--- a/crosslearner/benchmarks/__init__.py
+++ b/crosslearner/benchmarks/__init__.py
@@ -1,1 +1,5 @@
+"""Benchmarking utilities."""
+
 from .run_benchmarks import run
+
+__all__ = ["run"]

--- a/crosslearner/datasets/__init__.py
+++ b/crosslearner/datasets/__init__.py
@@ -15,6 +15,7 @@ def get_jobs_dataloader(*args, **kwargs):
 
     return _loader(*args, **kwargs)
 
+
 __all__ = [
     "get_toy_dataloader",
     "get_complex_dataloader",

--- a/crosslearner/datasets/complex.py
+++ b/crosslearner/datasets/complex.py
@@ -2,20 +2,26 @@ import torch
 from torch.utils.data import TensorDataset, DataLoader
 
 
-def get_complex_dataloader(batch_size: int = 256, n: int = 8000, p: int = 20, seed: int | None = None):
+def get_complex_dataloader(
+    batch_size: int = 256, n: int = 8000, p: int = 20, seed: int | None = None
+):
     """Return DataLoader with a more complex synthetic dataset."""
     if seed is not None:
         gen = torch.Generator().manual_seed(seed)
     else:
         gen = None
     X = torch.randn(n, p, generator=gen)
-    logit = (X[:, :3].prod(-1) + torch.sin(X[:, 3]) - X[:, 4] ** 2)
+    logit = X[:, :3].prod(-1) + torch.sin(X[:, 3]) - X[:, 4] ** 2
     pi = torch.sigmoid(logit)
     T = torch.bernoulli(pi, generator=gen).float()
     mu0 = X[:, 0] + torch.cos(X[:, 1]) + 0.5 * (X[:, 2] ** 2)
     mu1 = mu0 + torch.tanh(X[:, 3] + X[:, 4]) + X[:, 5]
     Y = torch.where(T.bool(), mu1, mu0) + 0.5 * torch.randn(n, generator=gen)
-    return DataLoader(TensorDataset(X, T.unsqueeze(-1), Y.unsqueeze(-1)), batch_size=batch_size, shuffle=True), (
+    return DataLoader(
+        TensorDataset(X, T.unsqueeze(-1), Y.unsqueeze(-1)),
+        batch_size=batch_size,
+        shuffle=True,
+    ), (
         mu0.unsqueeze(-1),
         mu1.unsqueeze(-1),
     )

--- a/crosslearner/models/baselines/slearner.py
+++ b/crosslearner/models/baselines/slearner.py
@@ -1,4 +1,3 @@
-from typing import Tuple
 import numpy as np
 import torch
 from sklearn.neural_network import MLPRegressor

--- a/crosslearner/models/baselines/xlearner.py
+++ b/crosslearner/models/baselines/xlearner.py
@@ -2,6 +2,8 @@ import numpy as np
 import torch
 from sklearn.neural_network import MLPRegressor
 
+from .tlearner import TLearner
+
 
 class XLearner:
     def __init__(self, p: int):
@@ -29,7 +31,6 @@ class XLearner:
     def predict_tau(self, X: np.ndarray) -> torch.Tensor:
         tau_t = self.model_tau_t.predict(X)
         tau_c = self.model_tau_c.predict(X)
-        return torch.tensor((1 - self.prop) * tau_t + self.prop * tau_c, dtype=torch.float32)
-
-
-from .tlearner import TLearner
+        return torch.tensor(
+            (1 - self.prop) * tau_t + self.prop * tau_c, dtype=torch.float32
+        )

--- a/crosslearner/training/history.py
+++ b/crosslearner/training/history.py
@@ -1,9 +1,11 @@
 from dataclasses import dataclass
 from typing import List, Optional
 
+
 @dataclass
 class EpochStats:
     """Metrics tracked for a single training epoch."""
+
     epoch: int
     loss_d: float
     loss_g: float
@@ -11,5 +13,6 @@ class EpochStats:
     loss_cons: float
     loss_adv: float
     val_pehe: Optional[float] = None
+
 
 History = List[EpochStats]

--- a/crosslearner/training/train_acx.py
+++ b/crosslearner/training/train_acx.py
@@ -64,7 +64,7 @@ def train_acx(
 
     history: History = []
     writer = SummaryWriter(tensorboard_logdir) if tensorboard_logdir else None
-    best_val = float('inf')
+    best_val = float("inf")
     epochs_no_improve = 0
 
     for epoch in range(epochs):
@@ -77,7 +77,9 @@ def train_acx(
 
             if warm_start > 0 and epoch < warm_start:
                 loss_y = mse(torch.where(Tb.bool(), m1, m0), Yb)
-                opt_g.zero_grad(); loss_y.backward(); opt_g.step()
+                opt_g.zero_grad()
+                loss_y.backward()
+                opt_g.step()
                 continue
 
             # ------------- discriminator update -------------------------
@@ -114,7 +116,9 @@ def train_acx(
                     real_lbl = real_lbl * 0.9
                     fake_lbl = fake_lbl + 0.1
                 loss_d = bce(real_logits, real_lbl) + bce(fake_logits, fake_lbl)
-            opt_d.zero_grad(); loss_d.backward(); opt_d.step()
+            opt_d.zero_grad()
+            loss_d.backward()
+            opt_d.step()
             if weight_clip is not None:
                 for p_ in model.disc.parameters():
                     p_.data.clamp_(-weight_clip, weight_clip)
@@ -144,11 +148,14 @@ def train_acx(
                 loss_g += eta_fm * loss_fm
 
             if gradient_reversal:
-                t_logits = model.discriminator(torch.cat([grad_reverse(hb, grl_weight), Yb, Tb], 1))
+                t_logits = model.discriminator(
+                    torch.cat([grad_reverse(hb, grl_weight), Yb, Tb], 1)
+                )
                 loss_grl = bce(t_logits, Tb)
                 loss_g += loss_grl
 
-            opt_g.zero_grad(); loss_g.backward();
+            opt_g.zero_grad()
+            loss_g.backward()
             if grad_clip:
                 nn.utils.clip_grad_norm_(model.parameters(), grad_clip)
             opt_g.step()

--- a/crosslearner/visualization.py
+++ b/crosslearner/visualization.py
@@ -1,6 +1,5 @@
 import torch
 from matplotlib import pyplot as plt
-from typing import Iterable
 
 from .models.acx import ACX
 from .training.history import History

--- a/tests/test_benchmark.py
+++ b/tests/test_benchmark.py
@@ -2,6 +2,6 @@ from crosslearner.benchmarks.run_benchmarks import run
 
 
 def test_run_benchmark_toy_short():
-    results = run('toy', replicates=1, epochs=1)
+    results = run("toy", replicates=1, epochs=1)
     assert len(results) == 1
     assert results[0] >= 0.0

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -1,4 +1,3 @@
-import torch
 from crosslearner.datasets.toy import get_toy_dataloader
 
 

--- a/tests/test_gan_invariants.py
+++ b/tests/test_gan_invariants.py
@@ -1,0 +1,43 @@
+import torch
+from crosslearner.models.acx import ACX
+from crosslearner.datasets.toy import get_toy_dataloader
+import torch.nn as nn
+
+
+def test_generator_preserves_batch_size():
+    model = ACX(p=3)
+    X = torch.randn(7, 3)
+    _, m0, m1, tau = model(X)
+    bs = X.size(0)
+    assert m0.size(0) == bs
+    assert m1.size(0) == bs
+    assert tau.size(0) == bs
+
+
+def test_discriminator_sigmoid_range():
+    model = ACX(p=3)
+    X = torch.randn(5, 3)
+    h, _, _, _ = model(X)
+    y = torch.randn(5, 1)
+    t = torch.randint(0, 2, (5, 1)).float()
+    logits = model.discriminator(h, y, t)
+    probs = torch.sigmoid(logits)
+    assert torch.all(probs >= 0)
+    assert torch.all(probs <= 1)
+    assert probs.shape == (5, 1)
+
+
+def test_losses_non_negative():
+    loader, _ = get_toy_dataloader(batch_size=4, n=4, p=3)
+    X, T, Y = next(iter(loader))
+    model = ACX(p=3)
+    h, m0, m1, _ = model(X)
+    mse = nn.MSELoss()
+    bce = nn.BCEWithLogitsLoss()
+    m_obs = torch.where(T.bool(), m1, m0)
+    loss_y = mse(m_obs, Y)
+    Ycf = torch.where(T.bool(), m0, m1)
+    fake_logits = model.discriminator(h, Ycf, T)
+    loss_adv = bce(fake_logits, torch.ones_like(fake_logits))
+    assert loss_y.item() >= 0
+    assert loss_adv.item() >= 0

--- a/tests/test_training.py
+++ b/tests/test_training.py
@@ -7,7 +7,7 @@ from crosslearner.evaluation.evaluate import evaluate
 def test_train_acx_short():
     torch.manual_seed(0)
     loader, (mu0, mu1) = get_toy_dataloader(batch_size=16, n=64, p=4)
-    model = train_acx(loader, p=4, device='cpu', epochs=2)
+    model = train_acx(loader, p=4, device="cpu", epochs=2)
     X = torch.cat([b[0] for b in loader])
     mu0_all = mu0
     mu1_all = mu1

--- a/tests/test_visualization.py
+++ b/tests/test_visualization.py
@@ -1,6 +1,7 @@
 import torch
 import matplotlib
-matplotlib.use('Agg')
+
+matplotlib.use("Agg")
 
 from crosslearner.visualization import plot_losses, scatter_tau
 from crosslearner.training.history import EpochStats
@@ -8,7 +9,11 @@ from crosslearner.models.acx import ACX
 
 
 def test_plot_losses_returns_figure():
-    hist = [EpochStats(epoch=0, loss_d=1.0, loss_g=2.0, loss_y=0.0, loss_cons=0.0, loss_adv=0.0)]
+    hist = [
+        EpochStats(
+            epoch=0, loss_d=1.0, loss_g=2.0, loss_y=0.0, loss_cons=0.0, loss_adv=0.0
+        )
+    ]
     fig = plot_losses(hist)
     assert fig is not None
     matplotlib.pyplot.close(fig)


### PR DESCRIPTION
## Summary
- add tests checking GAN shape and loss invariants
- enable ruff/black linting and Python 3.9-3.12 matrix including CUDA wheel install in CI
- fix lint violations and format files

## Testing
- `ruff check .`
- `black --check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684df75a1eac832486753c2c06631979