### PR TITLE
Add packaging and CLI entry points

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,16 +4,16 @@ This project provides a research friendly implementation of the **Adversarial–
 
 ## Getting Started
 
-Install dependencies:
+Install the package from source:
 
 ```bash
-pip install -r requirements.txt
+pip install .
 ```
 
 Run the toy example training loop:
 
 ```bash
-python train.py
+crosslearner-train
 ```
 
 The script trains an AC‑X model on a synthetic dataset and prints the final \sqrt{PEHE}.
@@ -26,7 +26,7 @@ TensorBoard log directory to write these metrics for live dashboards.
 To run a small benchmark across multiple datasets use:
 
 ```bash
-python -m crosslearner.benchmarks.run_benchmarks all --replicates 1 --epochs 1
+crosslearner-benchmarks all --replicates 1 --epochs 1
 ```
 
 This downloads the IHDP and Jobs datasets and prints the mean `sqrt(PEHE)` for each available task.

--- a/crosslearner/__main__.py
+++ b/crosslearner/__main__.py
@@ -1,0 +1,21 @@
+import torch
+
+from crosslearner.datasets.toy import get_toy_dataloader
+from crosslearner.training.train_acx import train_acx
+from crosslearner.evaluation.evaluate import evaluate
+
+
+def main() -> None:
+    """Run the toy training loop from the command line."""
+    loader, (mu0, mu1) = get_toy_dataloader()
+    device = "cuda" if torch.cuda.is_available() else "cpu"
+    model = train_acx(loader, p=10, device=device)
+    X = torch.cat([b[0] for b in loader]).to(device)
+    mu0_all = mu0.to(device)
+    mu1_all = mu1.to(device)
+    metric = evaluate(model, X, mu0_all, mu1_all)
+    print("\nsqrt(PEHE) (lower is better):", metric)
+
+
+if __name__ == "__main__":
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,30 @@
+[build-system]
+requires = ["setuptools>=61"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "crosslearner"
+version = "0.1.0"
+description = "Research implementation of the Adversarial-Consistency X-learner (AC-X)"
+readme = "README.md"
+requires-python = ">=3.10"
+authors = [{ name = "Matthew Simmons" }]
+license = { file = "LICENSE" }
+dependencies = [
+    "torch>=1.13",
+    "numpy",
+    "PyYAML",
+    "matplotlib",
+    "scikit-learn",
+    "causaldata",
+    "tensorboard",
+]
+
+[project.scripts]
+crosslearner-train = "crosslearner.__main__:main"
+crosslearner-benchmarks = "crosslearner.benchmarks.run_benchmarks:main"
+
+[tool.setuptools.packages.find]
+where = ["."]
+include = ["crosslearner*", "train"]
+


### PR DESCRIPTION
## Summary
- add pyproject.toml with setuptools build metadata
- expose `crosslearner-train` and `crosslearner-benchmarks` console scripts
- implement `crosslearner.__main__` for the default toy training run
- update README with pip install instructions and new commands

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_684e00726e7083248c894de460be5fb9