### PR TITLE
Improve README with AC-X details and clean toy dataset

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,35 +1,51 @@
 # crosslearner
 
-This project provides a research friendly implementation of the **Adversarial–Consistency X-learner (AC‑X)** described in `Prompt.txt`. The code is written in PyTorch and is structured for easy experimentation with adversarial tricks and benchmarking datasets.
+`crosslearner` implements the **Adversarial–Consistency X-learner (AC‑X)**, a variant of the X-learner that augments outcome models with an adversarial consistency term. The package is designed for reproducible research with numerous GAN tricks and benchmarking utilities.
 
-## Getting Started
+## Background
 
-Install the package from source:
+The X-learner approach estimates conditional treatment effects by combining outcome regressions for the treated and control groups with imputed pseudo-outcomes. See Küenzel *et&nbsp;al.* (2019) for details on the X-learner methodology.
+
+Recent work has explored adversarial training for counterfactual inference. In particular, Yoon, Jordon and van&nbsp;der Schaar (2018) introduced GANITE, demonstrating how generative adversarial networks can estimate individual treatment effects. AC‑X builds on these ideas by enforcing a consistency constraint between potential outcome heads and a dedicated treatment‑effect head.
+
+## AC‑X Objective
+
+Let $x$ denote covariates, $t \in \{0,1\}$ a binary treatment indicator and $y$ the observed outcome. The model predicts potential outcomes $\hat\mu_0(x)$ and $\hat\mu_1(x)$ as well as an explicit effect $\hat\tau(x)$. AC‑X minimises
+
+$$
+\mathcal{L} 
+= \sum_i \ell\bigl(y_i,\hat\mu_{t_i}(x_i)\bigr)
+  + \beta\_{\mathrm{cons}} \lVert \hat\tau(x_i) - (\hat\mu_1(x_i)-\hat\mu_0(x_i)) \rVert^2
+  + \gamma\_{\mathrm{adv}} \, \mathcal{L}\_{\mathrm{adv}},
+$$
+
+where $\ell$ is the squared error and $\mathcal{L}\_{\mathrm{adv}}$ is the standard discriminator loss encouraging generated counterfactual pairs to be indistinguishable from real data.
+
+## Installation
+
+Install from source:
 
 ```bash
 pip install .
 ```
 
-Run the toy example training loop:
+Run a toy training loop:
 
 ```bash
 crosslearner-train
 ```
 
-The script trains an AC‑X model on a synthetic dataset and prints the final \sqrt{PEHE}.
-The `train_acx` function also supports returning a full history of generator and
-discriminator losses to make experiment tracking easier. Optionally pass a
-TensorBoard log directory to write these metrics for live dashboards.
+The script trains an AC‑X model on a small synthetic dataset and prints the final $\sqrt{\mathrm{PEHE}}$ metric. Loss histories are optionally logged to TensorBoard for experiment tracking.
 
 ## Benchmarking
 
-To run a small benchmark across multiple datasets use:
+To benchmark across available datasets:
 
 ```bash
 crosslearner-benchmarks all --replicates 1 --epochs 1
 ```
 
-This downloads the IHDP and Jobs datasets and prints the mean `sqrt(PEHE)` for each available task.
+This downloads the IHDP and Jobs datasets and prints the mean $\sqrt{\mathrm{PEHE}}$ for each task.
 
 ## Repository Layout
 
@@ -39,14 +55,15 @@ This downloads the IHDP and Jobs datasets and prints the mean `sqrt(PEHE)` for e
 - `crosslearner/evaluation/` – metrics such as PEHE.
 - `crosslearner/configs/` – YAML configs with hyper‑parameters.
 
-The training code exposes toggles for Wasserstein loss (with gradient penalty or optional weight clipping), spectral normalisation, feature matching, instance noise, gradient reversal and two‑time‑scale update rule (TTUR). Early stopping on validation \sqrt{PEHE} is also available.
+The training code exposes options for Wasserstein loss with gradient penalty, spectral normalisation, feature matching, instance noise, gradient reversal and two‑time‑scale update rule (TTUR). Early stopping on validation $\sqrt{\mathrm{PEHE}}$ is also provided.
 
 Use the config file as a starting point for your own experiments on IHDP, ACIC or other datasets.
 
 ## Visualisation
 
-To diagnose training and model fit visually, pass the `History` returned by
-`train_acx` to `crosslearner.visualization.plot_losses` to plot generator and
-discriminator losses over time.  The module also provides
-`crosslearner.visualization.scatter_tau` for a scatter plot of predicted versus
-true treatment effects.
+The `History` returned by `train_acx` can be passed to `crosslearner.visualization.plot_losses` to plot generator and discriminator losses. The module also provides `crosslearner.visualization.scatter_tau` for a scatter plot of predicted versus true treatment effects.
+
+## References
+
+- J. Küenzel, J. Sekhon, P. Bickel, and B. Yu. *The X-Learner for Estimating Individualized Treatment Effects*. (2019).
+- J. Yoon, M. Jordon, and M. van der Schaar. *GANITE: Estimation of Individualized Treatment Effects using Generative Adversarial Nets*. (2018).

--- a/crosslearner/datasets/toy.py
+++ b/crosslearner/datasets/toy.py
@@ -3,7 +3,7 @@ from torch.utils.data import TensorDataset, DataLoader
 
 
 def get_toy_dataloader(batch_size: int = 256, n: int = 8000, p: int = 10):
-    """Return DataLoader with simple synthetic data used in Prompt.txt."""
+    """Return DataLoader with simple synthetic data."""
     X = torch.randn(n, p)
     pi = torch.sigmoid(X[:, :2].sum(-1))
     T = torch.bernoulli(pi).float()


### PR DESCRIPTION
## Summary
- document AC-X in more detail and cite the X-learner and GANITE papers
- explain the mathematical objective of AC-X
- remove link to `Prompt.txt`
- update toy dataset docstring

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684e09a5c7e083248f3f8f2ab39a6ca4