### PR TITLE
Add new dataset loaders and synthetic generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,12 +45,12 @@ To benchmark across available datasets:
 crosslearner-benchmarks all --replicates 1 --epochs 1
 ```
 
-This downloads the IHDP and Jobs datasets and prints the mean $\sqrt{\mathrm{PEHE}}$ for each task.
+This downloads the IHDP, Jobs, ACIC and Twins datasets and prints the mean $\sqrt{\mathrm{PEHE}}$ for each task.
 
 ## Repository Layout
 
 - `crosslearner/models/` – model definitions including `ACX`.
-- `crosslearner/datasets/` – data loaders (currently a toy synthetic generator).
+- `crosslearner/datasets/` – data loaders for IHDP, Jobs, ACIC, Twins, LaLonde and synthetic generators.
 - `crosslearner/training/` – training utilities and GAN tricks.
 - `crosslearner/evaluation/` – metrics such as PEHE.
 - `crosslearner/configs/` – YAML configs with hyper‑parameters.

--- a/crosslearner/benchmarks/run_benchmarks.py
+++ b/crosslearner/benchmarks/run_benchmarks.py
@@ -12,6 +12,11 @@ from crosslearner.datasets.toy import get_toy_dataloader
 from crosslearner.datasets.complex import get_complex_dataloader
 from crosslearner.datasets.ihdp import get_ihdp_dataloader
 from crosslearner.datasets.jobs import get_jobs_dataloader
+from crosslearner.datasets.acic2016 import get_acic2016_dataloader
+from crosslearner.datasets.acic2018 import get_acic2018_dataloader
+from crosslearner.datasets.twins import get_twins_dataloader
+from crosslearner.datasets.lalonde import get_lalonde_dataloader
+from crosslearner.datasets.synthetic import get_confounding_dataloader
 from crosslearner.training.train_acx import train_acx
 from crosslearner.evaluation.evaluate import evaluate
 
@@ -81,8 +86,34 @@ def run(dataset: str, replicates: int = 3, epochs: int = 30) -> List[float]:
         elif dataset == "jobs":
             loader, (mu0, mu1) = get_jobs_dataloader()
             p = loader.dataset.tensors[0].size(1)
+        elif dataset == "acic2016":
+            loader, (mu0, mu1) = get_acic2016_dataloader(seed=seed)
+            p = loader.dataset.tensors[0].size(1)
+        elif dataset == "acic2018":
+            loader, (mu0, mu1) = get_acic2018_dataloader(seed=seed)
+            p = loader.dataset.tensors[0].size(1)
+        elif dataset == "twins":
+            loader, (mu0, mu1) = get_twins_dataloader()
+            p = loader.dataset.tensors[0].size(1)
+        elif dataset == "lalonde":
+            loader, (mu0, mu1) = get_lalonde_dataloader()
+            p = loader.dataset.tensors[0].size(1)
+        elif dataset == "confounded":
+            loader, (mu0, mu1) = get_confounding_dataloader(seed=seed)
+            p = loader.dataset.tensors[0].size(1)
         elif dataset == "all":
-            all_ds = ["toy", "complex", "iris", "ihdp", "jobs"]
+            all_ds = [
+                "toy",
+                "complex",
+                "iris",
+                "ihdp",
+                "jobs",
+                "acic2016",
+                "acic2018",
+                "twins",
+                "lalonde",
+                "confounded",
+            ]
             summary = []
             for ds in all_ds:
                 res = run(ds, replicates, epochs)
@@ -108,7 +139,19 @@ def main():
     parser = argparse.ArgumentParser(description="Run CrossLearner benchmarks")
     parser.add_argument(
         "dataset",
-        choices=["toy", "complex", "iris", "ihdp", "jobs", "all"],
+        choices=[
+            "toy",
+            "complex",
+            "iris",
+            "ihdp",
+            "jobs",
+            "acic2016",
+            "acic2018",
+            "twins",
+            "lalonde",
+            "confounded",
+            "all",
+        ],
         help="dataset to benchmark or 'all'",
     )
     parser.add_argument("--replicates", type=int, default=3)

--- a/crosslearner/datasets/__init__.py
+++ b/crosslearner/datasets/__init__.py
@@ -2,6 +2,7 @@
 
 from .toy import get_toy_dataloader
 from .complex import get_complex_dataloader
+from .synthetic import get_confounding_dataloader
 
 
 def get_ihdp_dataloader(*args, **kwargs):
@@ -18,9 +19,42 @@ def get_jobs_dataloader(*args, **kwargs):
     return _loader(*args, **kwargs)
 
 
+def get_acic2016_dataloader(*args, **kwargs):
+    """Load the ACIC 2016 dataset on demand."""
+    from .acic2016 import get_acic2016_dataloader as _loader
+
+    return _loader(*args, **kwargs)
+
+
+def get_acic2018_dataloader(*args, **kwargs):
+    """Load the ACIC 2018 dataset on demand."""
+    from .acic2018 import get_acic2018_dataloader as _loader
+
+    return _loader(*args, **kwargs)
+
+
+def get_twins_dataloader(*args, **kwargs):
+    """Load the Twins dataset on demand."""
+    from .twins import get_twins_dataloader as _loader
+
+    return _loader(*args, **kwargs)
+
+
+def get_lalonde_dataloader(*args, **kwargs):
+    """Load the LaLonde dataset on demand."""
+    from .lalonde import get_lalonde_dataloader as _loader
+
+    return _loader(*args, **kwargs)
+
+
 __all__ = [
     "get_toy_dataloader",
     "get_complex_dataloader",
     "get_ihdp_dataloader",
     "get_jobs_dataloader",
+    "get_acic2016_dataloader",
+    "get_acic2018_dataloader",
+    "get_twins_dataloader",
+    "get_lalonde_dataloader",
+    "get_confounding_dataloader",
 ]

--- a/crosslearner/datasets/acic2016.py
+++ b/crosslearner/datasets/acic2016.py
@@ -1,0 +1,42 @@
+"""Loader for the ACIC 2016 benchmark dataset."""
+
+import os
+import urllib.request
+from typing import Tuple
+
+import numpy as np
+import torch
+from torch.utils.data import DataLoader, TensorDataset
+
+URL_2016 = "https://raw.githubusercontent.com/py-why/BenchmarkDatasets/master/acic2016/acic2016.npz"
+
+
+def _download(url: str, path: str) -> str:
+    if not os.path.exists(path):
+        urllib.request.urlretrieve(url, path)
+    return path
+
+
+def get_acic2016_dataloader(
+    seed: int = 0, batch_size: int = 256, *, data_dir: str | None = None
+) -> Tuple[DataLoader, Tuple[torch.Tensor, torch.Tensor]]:
+    """Return ACIC 2016 dataloader for the given replication index."""
+    data_dir = data_dir or os.path.join(os.path.dirname(__file__), "_data")
+    os.makedirs(data_dir, exist_ok=True)
+    fpath = _download(URL_2016, os.path.join(data_dir, "acic2016.npz"))
+    data = np.load(fpath)
+    X = data["x"][:, :, seed]
+    T = data["t"][:, seed]
+    Y = data["yf"][:, seed]
+    mu0 = data["mu0"][:, seed]
+    mu1 = data["mu1"][:, seed]
+    dset = TensorDataset(
+        torch.tensor(X, dtype=torch.float32),
+        torch.tensor(T, dtype=torch.float32).unsqueeze(-1),
+        torch.tensor(Y, dtype=torch.float32).unsqueeze(-1),
+    )
+    loader = DataLoader(dset, batch_size=batch_size, shuffle=True)
+    return loader, (
+        torch.tensor(mu0, dtype=torch.float32).unsqueeze(-1),
+        torch.tensor(mu1, dtype=torch.float32).unsqueeze(-1),
+    )

--- a/crosslearner/datasets/acic2018.py
+++ b/crosslearner/datasets/acic2018.py
@@ -1,0 +1,45 @@
+"""Loader for the ACIC 2018 benchmark dataset."""
+
+import os
+import urllib.request
+from typing import Tuple
+
+import numpy as np
+import torch
+from torch.utils.data import DataLoader, TensorDataset
+
+URL_2018 = "https://raw.githubusercontent.com/py-why/BenchmarkDatasets/master/acic2018/acic2018.npz"
+
+
+def _download(url: str, path: str) -> str:
+    if not os.path.exists(path):
+        urllib.request.urlretrieve(url, path)
+    return path
+
+
+def get_acic2018_dataloader(
+    seed: int = 0, batch_size: int = 256, *, data_dir: str | None = None
+) -> Tuple[DataLoader, Tuple[torch.Tensor, torch.Tensor]]:
+    """Return ACIC 2018 dataloader for the given replication index."""
+    data_dir = data_dir or os.path.join(os.path.dirname(__file__), "_data")
+    os.makedirs(data_dir, exist_ok=True)
+    fpath = _download(URL_2018, os.path.join(data_dir, "acic2018.npz"))
+    data = np.load(fpath)
+    X = data["x"][:, :, seed]
+    T = data["t"][:, seed]
+    Y = data["yf"][:, seed]
+    mu0 = data["mu0"][:, seed]
+    mu1 = data["mu1"][:, seed]
+    loader = DataLoader(
+        TensorDataset(
+            torch.tensor(X, dtype=torch.float32),
+            torch.tensor(T, dtype=torch.float32).unsqueeze(-1),
+            torch.tensor(Y, dtype=torch.float32).unsqueeze(-1),
+        ),
+        batch_size=batch_size,
+        shuffle=True,
+    )
+    return loader, (
+        torch.tensor(mu0, dtype=torch.float32).unsqueeze(-1),
+        torch.tensor(mu1, dtype=torch.float32).unsqueeze(-1),
+    )

--- a/crosslearner/datasets/lalonde.py
+++ b/crosslearner/datasets/lalonde.py
@@ -1,0 +1,17 @@
+"""Loader for the original LaLonde dataset."""
+
+import torch
+from torch.utils.data import DataLoader, TensorDataset
+from causaldata import nsw_mixtape
+
+
+def get_lalonde_dataloader(batch_size: int = 256):
+    """Return DataLoader for the LaLonde dataset."""
+    df = nsw_mixtape.load_pandas().data
+    y = torch.tensor(df["re78"].values, dtype=torch.float32).unsqueeze(-1)
+    t = torch.tensor(df["treat"].values, dtype=torch.float32).unsqueeze(-1)
+    x = torch.tensor(
+        df.drop(columns=["re78", "treat", "data_id"]).values, dtype=torch.float32
+    )
+    loader = DataLoader(TensorDataset(x, t, y), batch_size=batch_size, shuffle=True)
+    return loader, (None, None)

--- a/crosslearner/datasets/synthetic.py
+++ b/crosslearner/datasets/synthetic.py
@@ -1,0 +1,28 @@
+"""Synthetic data generator with configurable confounding."""
+
+import torch
+from torch.utils.data import TensorDataset, DataLoader
+
+
+def get_confounding_dataloader(
+    batch_size: int = 256,
+    n: int = 8000,
+    p: int = 10,
+    confounding: float = 0.0,
+    seed: int | None = None,
+):
+    """Return synthetic dataloader with adjustable confounding strength."""
+    gen = torch.Generator().manual_seed(seed) if seed is not None else None
+    X = torch.randn(n, p, generator=gen)
+    U = torch.randn(n, generator=gen)
+    logit = X[:, :2].sum(-1) + confounding * U
+    T = torch.bernoulli(torch.sigmoid(logit), generator=gen).float()
+    mu0 = X[:, 0] + confounding * U
+    mu1 = mu0 + torch.tanh(X[:, 1] + confounding * U)
+    Y = torch.where(T.bool(), mu1, mu0) + 0.5 * torch.randn(n, generator=gen)
+    loader = DataLoader(
+        TensorDataset(X, T.unsqueeze(-1), Y.unsqueeze(-1)),
+        batch_size=batch_size,
+        shuffle=True,
+    )
+    return loader, (mu0.unsqueeze(-1), mu1.unsqueeze(-1))

--- a/crosslearner/datasets/twins.py
+++ b/crosslearner/datasets/twins.py
@@ -1,0 +1,34 @@
+"""Loader for the Twins dataset."""
+
+import os
+import urllib.request
+from typing import Tuple
+
+import numpy as np
+import torch
+from torch.utils.data import DataLoader, TensorDataset
+
+URL_TWINS = "https://raw.githubusercontent.com/py-why/BenchmarkDatasets/master/twins/twins.npz"
+
+
+def _download(url: str, path: str) -> str:
+    if not os.path.exists(path):
+        urllib.request.urlretrieve(url, path)
+    return path
+
+
+def get_twins_dataloader(
+    batch_size: int = 256, *, data_dir: str | None = None
+) -> Tuple[DataLoader, Tuple[torch.Tensor, torch.Tensor]]:
+    """Return dataloader for the Twins dataset."""
+    data_dir = data_dir or os.path.join(os.path.dirname(__file__), "_data")
+    os.makedirs(data_dir, exist_ok=True)
+    fpath = _download(URL_TWINS, os.path.join(data_dir, "twins.npz"))
+    data = np.load(fpath)
+    x = torch.tensor(data["x"], dtype=torch.float32)
+    t = torch.tensor(data["t"], dtype=torch.float32).unsqueeze(-1)
+    y = torch.tensor(data["yf"], dtype=torch.float32).unsqueeze(-1)
+    mu0 = torch.tensor(data["mu0"], dtype=torch.float32).unsqueeze(-1)
+    mu1 = torch.tensor(data["mu1"], dtype=torch.float32).unsqueeze(-1)
+    loader = DataLoader(TensorDataset(x, t, y), batch_size=batch_size, shuffle=True)
+    return loader, (mu0, mu1)

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -2,7 +2,7 @@ import numpy as np
 from crosslearner.datasets.toy import get_toy_dataloader
 from crosslearner.datasets.complex import get_complex_dataloader
 from crosslearner.datasets.jobs import get_jobs_dataloader
-from crosslearner.datasets import ihdp
+from crosslearner.datasets import ihdp, acic2016, acic2018, twins, lalonde, synthetic
 
 
 def test_get_toy_dataloader_shapes():
@@ -59,3 +59,73 @@ def test_get_ihdp_dataloader_shapes(monkeypatch, tmp_path):
     assert Y.shape == (2, 1)
     assert mu0.shape == (5, 1)
     assert mu1.shape == (5, 1)
+
+
+def _fake_npz(path: str, n: int = 4, p: int = 3, replicate: bool = True) -> None:
+    if replicate:
+        x = np.zeros((n, p, 1))
+    else:
+        x = np.zeros((n, p))
+    t = np.zeros(n) if not replicate else np.zeros((n, 1))
+    if replicate:
+        y = np.zeros((n, 1))
+        mu0 = np.zeros((n, 1))
+        mu1 = np.ones((n, 1))
+    else:
+        y = np.zeros(n)
+        mu0 = np.zeros(n)
+        mu1 = np.ones(n)
+    data = dict(x=x, t=t, yf=y, mu0=mu0, mu1=mu1)
+    np.savez(path, **data)
+
+
+def test_get_acic2016_dataloader(monkeypatch, tmp_path):
+    monkeypatch.setattr(acic2016, "_download", lambda url, path: _fake_npz(path, replicate=True) or path)
+    loader, (mu0, mu1) = acic2016.get_acic2016_dataloader(batch_size=2, data_dir=tmp_path)
+    X, T, Y = next(iter(loader))
+    assert X.shape == (2, 3)
+    assert T.shape == (2, 1)
+    assert Y.shape == (2, 1)
+    assert mu0.shape == (4, 1)
+    assert mu1.shape == (4, 1)
+
+
+def test_get_acic2018_dataloader(monkeypatch, tmp_path):
+    monkeypatch.setattr(acic2018, "_download", lambda url, path: _fake_npz(path, replicate=True) or path)
+    loader, (mu0, mu1) = acic2018.get_acic2018_dataloader(batch_size=2, data_dir=tmp_path)
+    X, T, Y = next(iter(loader))
+    assert X.shape == (2, 3)
+    assert T.shape == (2, 1)
+    assert Y.shape == (2, 1)
+    assert mu0.shape == (4, 1)
+    assert mu1.shape == (4, 1)
+
+
+def test_get_twins_dataloader(monkeypatch, tmp_path):
+    monkeypatch.setattr(twins, "_download", lambda url, path: _fake_npz(path, replicate=False) or path)
+    loader, (mu0, mu1) = twins.get_twins_dataloader(batch_size=2, data_dir=tmp_path)
+    X, T, Y = next(iter(loader))
+    assert X.shape == (2, 3)
+    assert T.shape == (2, 1)
+    assert Y.shape == (2, 1)
+    assert mu0.shape == (4, 1)
+    assert mu1.shape == (4, 1)
+
+
+def test_get_lalonde_dataloader_shapes():
+    loader, (mu0, mu1) = lalonde.get_lalonde_dataloader(batch_size=4)
+    X, T, Y = next(iter(loader))
+    assert X.shape[0] == 4
+    assert T.shape == (4, 1)
+    assert Y.shape == (4, 1)
+    assert mu0 is None and mu1 is None
+
+
+def test_get_confounding_dataloader():
+    loader, (mu0, mu1) = synthetic.get_confounding_dataloader(batch_size=2, n=4, p=3, confounding=0.5, seed=0)
+    X, T, Y = next(iter(loader))
+    assert X.shape == (2, 3)
+    assert T.shape == (2, 1)
+    assert Y.shape == (2, 1)
+    assert mu0.shape == (4, 1)
+    assert mu1.shape == (4, 1)

--- a/tests/test_training.py
+++ b/tests/test_training.py
@@ -72,10 +72,15 @@ def test_run_benchmarks_all(monkeypatch):
     monkeypatch.setattr(run_benchmarks, "load_external_iris", fake_loader)
     monkeypatch.setattr(run_benchmarks, "get_ihdp_dataloader", fake_loader)
     monkeypatch.setattr(run_benchmarks, "get_jobs_dataloader", fake_loader)
+    monkeypatch.setattr(run_benchmarks, "get_acic2016_dataloader", fake_loader)
+    monkeypatch.setattr(run_benchmarks, "get_acic2018_dataloader", fake_loader)
+    monkeypatch.setattr(run_benchmarks, "get_twins_dataloader", fake_loader)
+    monkeypatch.setattr(run_benchmarks, "get_lalonde_dataloader", fake_loader)
+    monkeypatch.setattr(run_benchmarks, "get_confounding_dataloader", fake_loader)
     monkeypatch.setattr(run_benchmarks, "train_acx", lambda *a, **k: ACX(p=3))
     monkeypatch.setattr(run_benchmarks, "evaluate", lambda *a, **k: 0.0)
     results = run_benchmarks.run("all", replicates=1, epochs=1)
-    assert len(results) == 5
+    assert len(results) == 10
 
 
 def test_train_acx_options():


### PR DESCRIPTION
## Summary
- support ACIC 2016/2018, Twins, LaLonde and confounded synthetic datasets
- register new loaders in `datasets.__init__`
- extend benchmark runner and CLI options
- update tests for new loaders
- document datasets in the README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684e3220391c832498b7b637264ee0da