### PR TITLE
Add flexible architecture options

### DIFF
--- a/crosslearner/configs/default.yaml
+++ b/crosslearner/configs/default.yaml
@@ -1,6 +1,11 @@
 alpha_out: 1.0
 beta_cons: 10.0
 gamma_adv: 1.0
+rep_dim: 64
+phi_layers: [128]
+head_layers: [64]
+disc_layers: [64]
+activation: relu
 lr_g: 0.001
 lr_d: 0.001
 epochs: 30

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -10,3 +10,17 @@ def test_acx_forward_shapes():
     assert m0.shape == (2, 1)
     assert m1.shape == (2, 1)
     assert tau.shape == (2, 1)
+
+
+def test_acx_custom_architecture():
+    model = ACX(
+        p=3,
+        rep_dim=32,
+        phi_layers=(16, 16),
+        head_layers=(8,),
+        disc_layers=(8,),
+        activation="tanh",
+    )
+    X = torch.randn(4, 3)
+    h, *_ = model(X)
+    assert h.shape == (4, 32)

--- a/tests/test_training.py
+++ b/tests/test_training.py
@@ -122,3 +122,20 @@ def test_train_acx_options():
         )
     finally:
         ACX.discriminator = orig_disc
+
+
+def test_train_acx_custom_architecture():
+    loader, _ = get_toy_dataloader(batch_size=8, n=32, p=3)
+    model = train_acx(
+        loader,
+        p=3,
+        device="cpu",
+        epochs=1,
+        rep_dim=16,
+        phi_layers=[8],
+        head_layers=[4],
+        disc_layers=[4],
+        activation="elu",
+        verbose=False,
+    )
+    assert isinstance(model, ACX)


### PR DESCRIPTION
## Summary
- support arbitrary activations and layer shapes for the ACX network
- allow `train_acx` to forward new architecture parameters
- document defaults in the YAML config
- test custom architectures in models and training

## Testing
- `ruff check .`
- `black --check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684e41ecfc2883248b55e4d52a9c569c