### PR TITLE
Allow custom optimisers

### DIFF
--- a/crosslearner/configs/default.yaml
+++ b/crosslearner/configs/default.yaml
@@ -8,6 +8,9 @@ disc_layers: [64]
 activation: relu
 lr_g: 0.001
 lr_d: 0.001
+optimizer: adam
+opt_g_kwargs: {}
+opt_d_kwargs: {}
 epochs: 30
 grad_clip: 2.0
 warm_start: 0

--- a/tests/test_training.py
+++ b/tests/test_training.py
@@ -139,3 +139,18 @@ def test_train_acx_custom_architecture():
         verbose=False,
     )
     assert isinstance(model, ACX)
+
+
+def test_train_acx_custom_optimizer():
+    loader, _ = get_toy_dataloader(batch_size=8, n=32, p=3)
+    model = train_acx(
+        loader,
+        p=3,
+        device="cpu",
+        epochs=1,
+        optimizer="sgd",
+        opt_g_kwargs={"momentum": 0.0},
+        opt_d_kwargs={"momentum": 0.0},
+        verbose=False,
+    )
+    assert isinstance(model, ACX)


### PR DESCRIPTION
## Summary
- support custom optimisers in `train_acx`
- expose optimiser options in default YAML config
- test training with SGD

## Testing
- `black --check .`
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684e4a22d5ac8324af1748d25bddba45