### PR TITLE
Add DRLearner baseline

### DIFF
--- a/crosslearner/models/baselines/__init__.py
+++ b/crosslearner/models/baselines/__init__.py
@@ -3,5 +3,6 @@
 from .slearner import SLearner
 from .tlearner import TLearner
 from .xlearner import XLearner
+from .drlearner import DRLearner
 
-__all__ = ["SLearner", "TLearner", "XLearner"]
+__all__ = ["SLearner", "TLearner", "XLearner", "DRLearner"]

--- a/crosslearner/models/baselines/drlearner.py
+++ b/crosslearner/models/baselines/drlearner.py
@@ -1,0 +1,63 @@
+"""Doubly Robust (DR) learner baseline implementation."""
+
+from __future__ import annotations
+
+import numpy as np
+import torch
+from sklearn.linear_model import LogisticRegression
+from sklearn.neural_network import MLPRegressor
+
+
+class DRLearner:
+    """Doubly Robust meta-learner."""
+
+    def __init__(self, p: int) -> None:
+        """Create the learner.
+
+        Args:
+            p: Number of covariates.
+        """
+
+        self.model_mu0 = MLPRegressor(hidden_layer_sizes=(64, 64), max_iter=100)
+        self.model_mu1 = MLPRegressor(hidden_layer_sizes=(64, 64), max_iter=100)
+        self.model_tau = MLPRegressor(hidden_layer_sizes=(64, 64), max_iter=100)
+        self.model_e = LogisticRegression(max_iter=100)
+        self.p = p
+
+    def fit(self, X: np.ndarray, T: np.ndarray, Y: np.ndarray) -> None:
+        """Fit outcome, propensity and pseudo-outcome models.
+
+        Args:
+            X: Covariates ``(n, p)``.
+            T: Treatment indicators ``(n, 1)``.
+            Y: Outcomes ``(n, 1)``.
+        """
+
+        T = T.ravel()
+        self.model_mu0.fit(X, Y.ravel())
+        self.model_mu1.fit(X, Y.ravel())
+        self.model_e.fit(X, T)
+        mu0_hat = self.model_mu0.predict(X)
+        mu1_hat = self.model_mu1.predict(X)
+        e_hat = self.model_e.predict_proba(X)[:, 1]
+        tau_tilde = (
+            mu1_hat
+            - mu0_hat
+            + (T - e_hat)
+            / (e_hat * (1 - e_hat))
+            * (Y.ravel() - np.where(T == 1, mu1_hat, mu0_hat))
+        )
+        self.model_tau.fit(X, tau_tilde)
+
+    def predict_tau(self, X: np.ndarray) -> torch.Tensor:
+        """Predict treatment effects.
+
+        Args:
+            X: Covariate matrix ``(n, p)``.
+
+        Returns:
+            Predicted treatment effects.
+        """
+
+        tau = self.model_tau.predict(X)
+        return torch.tensor(tau, dtype=torch.float32)

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -2,7 +2,7 @@ import numpy as np
 import torch
 
 from crosslearner.models.acx import ACX
-from crosslearner.models.baselines import SLearner, TLearner, XLearner
+from crosslearner.models.baselines import DRLearner, SLearner, TLearner, XLearner
 
 
 def _make_data(n=20, p=3):
@@ -42,6 +42,14 @@ def test_tlearner_fit_predict():
 def test_xlearner_fit_predict():
     X, T, Y = _make_data()
     model = XLearner(p=X.shape[1])
+    model.fit(X, T, Y)
+    tau = model.predict_tau(X)
+    assert tau.shape == (X.shape[0],)
+
+
+def test_drlearner_fit_predict():
+    X, T, Y = _make_data()
+    model = DRLearner(p=X.shape[1])
     model.fit(X, T, Y)
     tau = model.predict_tau(X)
     assert tau.shape == (X.shape[0],)


### PR DESCRIPTION
## Summary
- add `DRLearner` implementation
- expose new baseline in `crosslearner.models.baselines`
- test `DRLearner` in `tests/test_models.py`

## Testing
- `ruff check .`
- `black --check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684e588b7a348324a9e709751fa5ee9e