### PR TITLE
Enhance benchmarking metrics

### DIFF
--- a/crosslearner/evaluation/metrics.py
+++ b/crosslearner/evaluation/metrics.py
@@ -1,5 +1,8 @@
-"""Evaluation metrics."""
+"""Evaluation metrics for treatment effect models."""
 
+from __future__ import annotations
+
+import numpy as np
 import torch
 
 
@@ -14,3 +17,51 @@ def pehe(tau_hat: torch.Tensor, tau_true: torch.Tensor) -> float:
         Square-root PEHE.
     """
     return torch.mean((tau_hat - tau_true) ** 2).sqrt().item()
+
+
+def policy_risk(tau_hat: torch.Tensor, mu0: torch.Tensor, mu1: torch.Tensor) -> float:
+    """Return the policy risk of using ``tau_hat`` for treatment decisions.
+
+    The function compares the outcome under the policy implied by ``tau_hat``
+    against always choosing the best potential outcome.
+    """
+
+    opt_outcome = torch.max(mu0, mu1)
+    policy = (tau_hat > 0).float()
+    pred_outcome = mu0 * (1.0 - policy) + mu1 * policy
+    return torch.mean(opt_outcome - pred_outcome).item()
+
+
+def ate_error(tau_hat: torch.Tensor, mu0: torch.Tensor, mu1: torch.Tensor) -> float:
+    """Return estimation error for the Average Treatment Effect (ATE)."""
+
+    ate_hat = torch.mean(tau_hat)
+    ate_true = torch.mean(mu1 - mu0)
+    return (ate_hat - ate_true).item()
+
+
+def att_error(
+    tau_hat: torch.Tensor, mu0: torch.Tensor, mu1: torch.Tensor, t: torch.Tensor
+) -> float:
+    """Return estimation error for the ATT (Average Treatment effect on Treated)."""
+
+    mask = t.view(-1).bool()
+    att_hat = torch.mean(tau_hat.view(-1)[mask])
+    att_true = torch.mean((mu1 - mu0).view(-1)[mask])
+    return (att_hat - att_true).item()
+
+
+def bootstrap_ci(
+    values: torch.Tensor, *, level: float = 0.95, n_boot: int = 1000
+) -> tuple[float, float]:
+    """Return a bootstrap confidence interval for the mean of ``values``."""
+
+    arr = values.view(-1).cpu().numpy()
+    means = []
+    for _ in range(n_boot):
+        sample = np.random.choice(arr, size=arr.size, replace=True)
+        means.append(sample.mean())
+    alpha = 1.0 - level
+    lower = float(np.percentile(means, 100 * alpha / 2))
+    upper = float(np.percentile(means, 100 * (1 - alpha / 2)))
+    return lower, upper

--- a/crosslearner/visualization.py
+++ b/crosslearner/visualization.py
@@ -141,3 +141,30 @@ def plot_residuals(y_true: torch.Tensor, y_pred: torch.Tensor):
     ax.set_ylabel("residual")
     fig.tight_layout()
     return fig
+
+
+def plot_cate_calibration(
+    tau_hat: torch.Tensor, tau_true: torch.Tensor, bins: int = 10
+) -> plt.Figure:
+    """Return a calibration curve for CATE estimates."""
+
+    tau_hat = tau_hat.view(-1)
+    tau_true = tau_true.view(-1)
+    edges = torch.linspace(tau_hat.min(), tau_hat.max(), bins + 1)
+    bin_idx = torch.bucketize(tau_hat, edges, right=True)
+    pred_means = []
+    true_means = []
+    for i in range(1, len(edges)):
+        mask = bin_idx == i
+        if mask.any():
+            pred_means.append(float(tau_hat[mask].mean()))
+            true_means.append(float(tau_true[mask].mean()))
+    fig, ax = plt.subplots()
+    ax.plot(pred_means, true_means, marker="o")
+    minv = float(min(pred_means + true_means))
+    maxv = float(max(pred_means + true_means))
+    ax.plot([minv, maxv], [minv, maxv], "r--", linewidth=1)
+    ax.set_xlabel("predicted tau")
+    ax.set_ylabel("true tau")
+    fig.tight_layout()
+    return fig

--- a/tests/test_benchmark.py
+++ b/tests/test_benchmark.py
@@ -4,4 +4,6 @@ from crosslearner.benchmarks.run_benchmarks import run
 def test_run_benchmark_toy_short():
     results = run("toy", replicates=1, epochs=1)
     assert len(results) == 1
-    assert results[0] >= 0.0
+    metrics = results[0]
+    assert "pehe" in metrics and "policy_risk" in metrics
+    assert metrics["pehe"] >= 0.0

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -1,5 +1,11 @@
 import torch
-from crosslearner.evaluation.metrics import pehe
+from crosslearner.evaluation.metrics import (
+    pehe,
+    policy_risk,
+    ate_error,
+    att_error,
+    bootstrap_ci,
+)
 
 
 def test_pehe():
@@ -8,3 +14,17 @@ def test_pehe():
     result = pehe(tau_hat, tau_true)
     expected = (0.5) ** 0.5
     assert abs(result - expected) < 1e-6
+
+
+def test_additional_metrics():
+    mu0 = torch.zeros(4, 1)
+    mu1 = torch.ones(4, 1)
+    tau_hat = torch.tensor([[0.5], [0.5], [-0.5], [-0.5]])
+    risk = policy_risk(tau_hat, mu0, mu1)
+    assert risk >= 0.0
+    t = torch.tensor([[0], [1], [0], [1]])
+    tau_hat = torch.ones(4, 1)
+    assert abs(ate_error(tau_hat, mu0, mu1)) < 1e-6
+    assert abs(att_error(tau_hat, mu0, mu1, t)) < 1e-6
+    low, high = bootstrap_ci(tau_hat.view(-1), n_boot=10)
+    assert low <= high

--- a/tests/test_training.py
+++ b/tests/test_training.py
@@ -81,6 +81,7 @@ def test_run_benchmarks_all(monkeypatch):
     monkeypatch.setattr(run_benchmarks, "evaluate", lambda *a, **k: 0.0)
     results = run_benchmarks.run("all", replicates=1, epochs=1)
     assert len(results) == 10
+    assert all(isinstance(r, float) for r in results)
 
 
 def test_train_acx_options():

--- a/tests/test_visualization.py
+++ b/tests/test_visualization.py
@@ -10,6 +10,7 @@ from crosslearner.visualization import (
     plot_covariate_balance,
     plot_propensity_overlap,
     plot_residuals,
+    plot_cate_calibration,
 )
 from crosslearner.training.history import EpochStats
 from crosslearner.models.acx import ACX
@@ -63,5 +64,13 @@ def test_plot_residuals_returns_figure():
     y_true = torch.randn(5, 1)
     y_pred = torch.randn(5, 1)
     fig = plot_residuals(y_true, y_pred)
+    assert fig is not None
+    matplotlib.pyplot.close(fig)
+
+
+def test_plot_cate_calibration_returns_figure():
+    tau_hat = torch.randn(20, 1)
+    tau_true = torch.randn(20, 1)
+    fig = plot_cate_calibration(tau_hat, tau_true)
     assert fig is not None
     matplotlib.pyplot.close(fig)


### PR DESCRIPTION
## Summary
- expand evaluation metrics with policy risk, ATE/ATT errors and bootstrap CI
- add calibration plotting utility
- record extra metrics when running benchmarks
- update tests for new metrics and benchmark outputs

## Testing
- `ruff check .`
- `black . --check`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684e5bc6f0488324a83122447369bf87