### PR TITLE
Add experiment manager with cross-validation and Optuna

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,30 @@ study.optimize(objective, n_trials=50)
 
 See :doc:`hyperparameter_sweeps` in the documentation for more details.
 
+## Experiment Manager
+
+To streamline large-scale experiments the package ships with
+``ExperimentManager`` which marries cross-validation, Optuna searches and
+TensorBoard logging. It takes a data loader and true potential outcomes and
+automatically performs repeated training and evaluation:
+
+```python
+from crosslearner.datasets.toy import get_toy_dataloader
+from crosslearner.experiments import ExperimentManager
+import optuna
+
+loader, (mu0, mu1) = get_toy_dataloader()
+manager = ExperimentManager(loader, mu0, mu1, p=10, folds=3, log_dir="runs")
+
+def space(trial: optuna.Trial) -> dict:
+    return {"rep_dim": trial.suggest_int("rep_dim", 32, 64), "epochs": 5}
+
+study = manager.optimize(space, n_trials=10)
+print("best PEHE", study.best_value)
+```
+
+Each fold and trial is logged under ``log_dir`` to make results reproducible.
+
 ## Repository Layout
 
 - `crosslearner/models/` – model definitions including `ACX`.

--- a/crosslearner/__init__.py
+++ b/crosslearner/__init__.py
@@ -4,6 +4,7 @@ from .datasets import get_toy_dataloader, get_complex_dataloader
 from .training.train_acx import train_acx
 from .training.history import EpochStats, History
 from .evaluation.evaluate import evaluate
+from .experiments import ExperimentManager, cross_validate_acx
 from .visualization import (
     plot_losses,
     scatter_tau,
@@ -26,4 +27,6 @@ __all__ = [
     "plot_covariate_balance",
     "plot_propensity_overlap",
     "plot_residuals",
+    "ExperimentManager",
+    "cross_validate_acx",
 ]

--- a/crosslearner/experiments/__init__.py
+++ b/crosslearner/experiments/__init__.py
@@ -1,0 +1,5 @@
+"""Experiment management utilities."""
+
+from .manager import ExperimentManager, cross_validate_acx
+
+__all__ = ["ExperimentManager", "cross_validate_acx"]

--- a/crosslearner/experiments/manager.py
+++ b/crosslearner/experiments/manager.py
@@ -1,0 +1,151 @@
+"""Experiment management utilities for AC-X models."""
+
+from __future__ import annotations
+
+import os
+from typing import Callable, Optional, TYPE_CHECKING
+
+import torch
+from torch.utils.data import DataLoader, TensorDataset
+from sklearn.model_selection import KFold
+
+from ..training.train_acx import train_acx
+from ..evaluation.evaluate import evaluate
+
+if TYPE_CHECKING:  # pragma: no cover
+    import optuna
+
+
+def cross_validate_acx(
+    loader: DataLoader,
+    mu0: torch.Tensor,
+    mu1: torch.Tensor,
+    *,
+    p: int,
+    folds: int = 5,
+    device: Optional[str] = None,
+    log_dir: Optional[str] = None,
+    seed: int = 0,
+    **train_kwargs,
+) -> float:
+    """Return mean validation PEHE across ``folds`` splits.
+
+    Args:
+        loader: Data loader providing ``(X, T, Y)`` tuples.
+        mu0: Potential outcomes under control.
+        mu1: Potential outcomes under treatment.
+        p: Number of covariates.
+        folds: Number of cross-validation folds.
+        device: Device string passed to :func:`train_acx`.
+        log_dir: Optional directory for TensorBoard logs. Each fold logs to
+            ``log_dir/fold_i``.
+        seed: Random seed for reproducible splits.
+        **train_kwargs: Additional arguments passed to :func:`train_acx`.
+
+    Returns:
+        Mean validation :math:`\sqrt{\mathrm{PEHE}}` across folds.
+    """
+    device = device or ("cuda" if torch.cuda.is_available() else "cpu")
+    dataset: TensorDataset = loader.dataset  # type: ignore[arg-type]
+    X, T, Y = dataset.tensors
+    kf = KFold(n_splits=folds, shuffle=True, random_state=seed)
+    metrics = []
+    batch_size = loader.batch_size or 32
+
+    for i, (train_idx, val_idx) in enumerate(kf.split(X)):
+        train_ds = TensorDataset(X[train_idx], T[train_idx], Y[train_idx])
+        train_loader = DataLoader(train_ds, batch_size=batch_size, shuffle=True)
+
+        val_data = (
+            X[val_idx].to(device),
+            mu0[val_idx].to(device),
+            mu1[val_idx].to(device),
+        )
+        fold_dir = os.path.join(log_dir, f"fold_{i}") if log_dir else None
+        model = train_acx(
+            train_loader,
+            p,
+            device=device,
+            val_data=val_data,
+            tensorboard_logdir=fold_dir,
+            **train_kwargs,
+        )
+        metric = evaluate(model, *val_data)
+        metrics.append(metric)
+    return float(sum(metrics) / len(metrics))
+
+
+class ExperimentManager:
+    """Run cross-validation and Optuna searches for AC-X models."""
+
+    def __init__(
+        self,
+        loader: DataLoader,
+        mu0: torch.Tensor,
+        mu1: torch.Tensor,
+        p: int,
+        *,
+        folds: int = 5,
+        device: Optional[str] = None,
+        log_dir: Optional[str] = None,
+        seed: int = 0,
+    ) -> None:
+        self.loader = loader
+        self.mu0 = mu0
+        self.mu1 = mu1
+        self.p = p
+        self.folds = folds
+        self.device = device
+        self.log_dir = log_dir
+        self.seed = seed
+
+    def cross_validate(self, **train_kwargs) -> float:
+        """Cross-validate ``train_acx`` with stored data."""
+        return cross_validate_acx(
+            self.loader,
+            self.mu0,
+            self.mu1,
+            p=self.p,
+            folds=self.folds,
+            device=self.device,
+            log_dir=self.log_dir,
+            seed=self.seed,
+            **train_kwargs,
+        )
+
+    def optimize(
+        self,
+        space_fn: Callable[["optuna.Trial"], dict],
+        *,
+        n_trials: int = 50,
+        direction: str = "minimize",
+    ) -> "optuna.Study":
+        """Run an Optuna search over ``n_trials`` using ``space_fn``.
+
+        ``space_fn`` should take an :class:`optuna.Trial` and return a dict
+        of parameters passed to :func:`train_acx`.
+        """
+        import optuna
+
+        def objective(trial: "optuna.Trial") -> float:
+            params = space_fn(trial)
+            trial_dir = (
+                os.path.join(self.log_dir, f"trial_{trial.number}")
+                if self.log_dir
+                else None
+            )
+            return cross_validate_acx(
+                self.loader,
+                self.mu0,
+                self.mu1,
+                p=self.p,
+                folds=self.folds,
+                device=self.device,
+                log_dir=trial_dir,
+                seed=self.seed,
+                **params,
+            )
+
+        study = optuna.create_study(direction=direction)
+        study.optimize(objective, n_trials=n_trials)
+        return study

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ dependencies = [
     "scikit-learn",
     "causaldata",
     "tensorboard",
+    "optuna",
 ]
 
 [project.scripts]

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ matplotlib
 scikit-learn
 causaldata
 tensorboard
+optuna

--- a/tests/test_experiment_manager.py
+++ b/tests/test_experiment_manager.py
@@ -1,0 +1,32 @@
+import optuna
+from crosslearner.datasets.toy import get_toy_dataloader
+from crosslearner.experiments import ExperimentManager, cross_validate_acx
+
+
+def test_cross_validate(tmp_path):
+    loader, (mu0, mu1) = get_toy_dataloader(batch_size=4, n=16, p=3)
+    metric = cross_validate_acx(
+        loader,
+        mu0,
+        mu1,
+        p=3,
+        folds=2,
+        device="cpu",
+        log_dir=str(tmp_path),
+        epochs=1,
+    )
+    assert metric >= 0.0
+    assert (tmp_path / "fold_0").exists()
+
+
+def test_experiment_manager_optuna(tmp_path):
+    loader, (mu0, mu1) = get_toy_dataloader(batch_size=4, n=16, p=3)
+    manager = ExperimentManager(
+        loader, mu0, mu1, p=3, folds=2, device="cpu", log_dir=str(tmp_path)
+    )
+
+    def space(trial: optuna.Trial) -> dict:
+        return {"epochs": 1, "rep_dim": trial.suggest_int("rep_dim", 4, 8)}
+
+    study = manager.optimize(space, n_trials=1)
+    assert len(study.trials) == 1


### PR DESCRIPTION
## Summary
- implement `cross_validate_acx` and `ExperimentManager` for reproducible hyperparameter sweeps
- expose experiment manager in the public API
- document the new workflow in `README`
- add Optuna as a dependency
- test cross-validation and Optuna integration

## Testing
- `ruff check .`
- `black --check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684e715b3a7483249c258764d0464176