### PR TITLE
Fix ACIC dataset download errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,9 @@ cross-validated $\sqrt{\mathrm{PEHE}}$ across the built-in synthetic datasets:
 
 - `crosslearner/models/` – model definitions including `ACX`.
 - `crosslearner/datasets/` – data loaders for IHDP, Jobs, ACIC, Twins, LaLonde and synthetic generators.
+  The ACIC loaders attempt to download `.npz` files from GitHub. If the URLs are
+  unavailable, download the files manually and place them under
+  `crosslearner/datasets/_data`.
 - `crosslearner/training/` – training utilities and GAN tricks.
 - `crosslearner/evaluation/` – metrics such as PEHE.
 - `crosslearner/configs/` – YAML configs with hyper‑parameters.

--- a/crosslearner/datasets/acic2016.py
+++ b/crosslearner/datasets/acic2016.py
@@ -12,8 +12,20 @@ URL_2016 = "https://raw.githubusercontent.com/py-why/BenchmarkDatasets/master/ac
 
 
 def _download(url: str, path: str) -> str:
-    if not os.path.exists(path):
+    """Download ``url`` to ``path`` if missing.
+
+    Raises a ``RuntimeError`` with a helpful message when the download fails so
+    users can fetch the file manually.
+    """
+    if os.path.exists(path):
+        return path
+    try:
         urllib.request.urlretrieve(url, path)
+    except Exception as exc:  # pragma: no cover - network errors
+        raise RuntimeError(
+            f"Failed to download ACIC 2016 dataset from {url}. "
+            f"Please download the file manually and place it at {path}."
+        ) from exc
     return path
 
 

--- a/crosslearner/datasets/acic2018.py
+++ b/crosslearner/datasets/acic2018.py
@@ -12,8 +12,20 @@ URL_2018 = "https://raw.githubusercontent.com/py-why/BenchmarkDatasets/master/ac
 
 
 def _download(url: str, path: str) -> str:
-    if not os.path.exists(path):
+    """Download ``url`` to ``path`` if missing.
+
+    Raises a ``RuntimeError`` with instructions for manual download when the
+    remote file cannot be retrieved.
+    """
+    if os.path.exists(path):
+        return path
+    try:
         urllib.request.urlretrieve(url, path)
+    except Exception as exc:  # pragma: no cover - network errors
+        raise RuntimeError(
+            f"Failed to download ACIC 2018 dataset from {url}. "
+            f"Please download the file manually and place it at {path}."
+        ) from exc
     return path
 
 


### PR DESCRIPTION
## Summary
- handle download failures in ACIC dataset loaders with clear RuntimeError
- document manual download instructions in README

## Testing
- `ruff check .`
- `black --check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684e9992737483249212dbc778c55eec