### PR TITLE
Improve train_acx input handling

### DIFF
--- a/crosslearner/training/train_acx.py
+++ b/crosslearner/training/train_acx.py
@@ -166,6 +166,10 @@ def train_acx(
         batch_count = 0
         for Xb, Tb, Yb in loader:
             Xb, Tb, Yb = Xb.to(device), Tb.to(device), Yb.to(device)
+            if Tb.ndim == 1:
+                Tb = Tb.unsqueeze(-1)
+            if Yb.ndim == 1:
+                Yb = Yb.unsqueeze(-1)
             hb, m0, m1, tau = model(Xb)
 
             if warm_start > 0 and epoch < warm_start:
@@ -270,6 +274,10 @@ def train_acx(
         )
         if val_data is not None:
             Xv, mu0v, mu1v = (v.to(device) for v in val_data)
+            if mu0v.ndim == 1:
+                mu0v = mu0v.unsqueeze(-1)
+            if mu1v.ndim == 1:
+                mu1v = mu1v.unsqueeze(-1)
             val_pehe = evaluate(model, Xv, mu0v, mu1v)
             stats.val_pehe = val_pehe
             if writer:

--- a/tests/test_training.py
+++ b/tests/test_training.py
@@ -5,6 +5,7 @@ from crosslearner.datasets.toy import get_toy_dataloader
 from crosslearner.evaluation.evaluate import evaluate
 from crosslearner.models.acx import ACX
 from crosslearner.training.train_acx import train_acx
+from torch.utils.data import DataLoader, TensorDataset
 
 
 def test_train_acx_short():
@@ -141,4 +142,15 @@ def test_train_acx_custom_optimizer():
         opt_d_kwargs={"momentum": 0.0},
         verbose=False,
     )
+    assert isinstance(model, ACX)
+
+
+def test_train_acx_1d_targets():
+    X = torch.randn(16, 4)
+    T = torch.randint(0, 2, (16,))
+    mu0 = torch.randn(16)
+    mu1 = mu0 + torch.randn(16)
+    Y = torch.where(T.bool(), mu1, mu0) + 0.1 * torch.randn(16)
+    loader = DataLoader(TensorDataset(X, T, Y), batch_size=8)
+    model = train_acx(loader, p=4, device="cpu", epochs=1, verbose=False)
     assert isinstance(model, ACX)


### PR DESCRIPTION
## Summary
- allow train_acx to accept 1D treatment/outcome tensors
- handle 1D validation arrays
- test that 1D labels work

## Testing
- `ruff check .`
- `black --check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684ea1ad4f3c832490e079b157dbb338