### PR TITLE
Add input dimension validation to train_acx

### DIFF
--- a/crosslearner/training/train_acx.py
+++ b/crosslearner/training/train_acx.py
@@ -98,6 +98,18 @@ def train_acx(
     """
     device = device or ("cuda" if torch.cuda.is_available() else "cpu")
 
+    # sanity check for feature dimension mismatches
+    feat_dim = None
+    try:
+        feat_dim = loader.dataset[0][0].shape[-1]
+    except Exception:
+        # ignore datasets without random access
+        pass
+    if feat_dim is not None and feat_dim != p:
+        raise ValueError(
+            f"Input dimension mismatch: dataset has {feat_dim} features but p={p}"
+        )
+
     if isinstance(activation, str):
         act_name = activation.lower()
         activations = {

--- a/tests/test_training.py
+++ b/tests/test_training.py
@@ -5,6 +5,7 @@ from crosslearner.datasets.toy import get_toy_dataloader
 from crosslearner.evaluation.evaluate import evaluate
 from crosslearner.models.acx import ACX
 from crosslearner.training.train_acx import train_acx
+import pytest
 from torch.utils.data import DataLoader, TensorDataset
 
 
@@ -173,3 +174,9 @@ def test_instance_noise_keeps_targets(monkeypatch):
     train_acx(loader, p=4, device="cpu", epochs=1, instance_noise=True, verbose=False)
 
     assert torch.allclose(targets[0], loader.dataset.tensors[2][:4])
+
+
+def test_train_acx_feature_mismatch():
+    loader, _ = get_toy_dataloader(batch_size=4, n=8, p=4)
+    with pytest.raises(ValueError):
+        train_acx(loader, p=3, device="cpu", epochs=1, verbose=False)


### PR DESCRIPTION
## Summary
- validate feature dimension of dataloader in `train_acx`
- test that mismatched `p` raises ValueError

## Testing
- `ruff check .`
- `black --check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684f410a72548324abfb64c2880a0fd0