### PR TITLE
Improve train_acx validation

### DIFF
--- a/crosslearner/training/train_acx.py
+++ b/crosslearner/training/train_acx.py
@@ -98,6 +98,11 @@ def train_acx(
     """
     device = device or ("cuda" if torch.cuda.is_available() else "cpu")
 
+    if grad_clip is not None and grad_clip < 0:
+        raise ValueError("grad_clip must be non-negative")
+    if weight_clip is not None and weight_clip <= 0:
+        raise ValueError("weight_clip must be positive")
+
     # sanity check for feature dimension mismatches
     feat_dim = None
     try:

--- a/tests/test_training.py
+++ b/tests/test_training.py
@@ -180,3 +180,27 @@ def test_train_acx_feature_mismatch():
     loader, _ = get_toy_dataloader(batch_size=4, n=8, p=4)
     with pytest.raises(ValueError):
         train_acx(loader, p=3, device="cpu", epochs=1, verbose=False)
+
+
+def test_train_acx_invalid_activation():
+    loader, _ = get_toy_dataloader(batch_size=4, n=8, p=4)
+    with pytest.raises(ValueError):
+        train_acx(loader, p=4, device="cpu", epochs=1, activation="bad", verbose=False)
+
+
+def test_train_acx_invalid_optimizer():
+    loader, _ = get_toy_dataloader(batch_size=4, n=8, p=4)
+    with pytest.raises(ValueError):
+        train_acx(loader, p=4, device="cpu", epochs=1, optimizer="bad", verbose=False)
+
+
+def test_train_acx_negative_grad_clip():
+    loader, _ = get_toy_dataloader(batch_size=4, n=8, p=4)
+    with pytest.raises(ValueError):
+        train_acx(loader, p=4, device="cpu", epochs=1, grad_clip=-1, verbose=False)
+
+
+def test_train_acx_negative_weight_clip():
+    loader, _ = get_toy_dataloader(batch_size=4, n=8, p=4)
+    with pytest.raises(ValueError):
+        train_acx(loader, p=4, device="cpu", epochs=1, weight_clip=-0.1, verbose=False)


### PR DESCRIPTION
## Summary
- check `grad_clip` and `weight_clip` inputs for invalid negative values
- expand `train_acx` test coverage to ensure invalid options raise `ValueError`

## Testing
- `ruff check .`
- `black --check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684f43f0b4f883248116c034bc12850b