### PR TITLE
Add validation for val_data dimensions

### DIFF
--- a/crosslearner/training/train_acx.py
+++ b/crosslearner/training/train_acx.py
@@ -110,6 +110,16 @@ def train_acx(
             f"Input dimension mismatch: dataset has {feat_dim} features but p={p}"
         )
 
+    if val_data is not None:
+        Xv, mu0v, mu1v = val_data
+        if Xv.size(-1) != p:
+            raise ValueError(
+                "Validation data dimension mismatch: "
+                f"expected {p} features but got {Xv.size(-1)}"
+            )
+        if Xv.size(0) != mu0v.size(0) or Xv.size(0) != mu1v.size(0):
+            raise ValueError("Validation data tensors must have the same length")
+
     if isinstance(activation, str):
         act_name = activation.lower()
         activations = {

--- a/tests/test_training.py
+++ b/tests/test_training.py
@@ -180,3 +180,19 @@ def test_train_acx_feature_mismatch():
     loader, _ = get_toy_dataloader(batch_size=4, n=8, p=4)
     with pytest.raises(ValueError):
         train_acx(loader, p=3, device="cpu", epochs=1, verbose=False)
+
+
+def test_train_acx_val_data_mismatch():
+    loader, _ = get_toy_dataloader(batch_size=4, n=8, p=4)
+    val_X = torch.randn(10, 5)
+    mu0 = torch.randn(10, 1)
+    mu1 = torch.randn(10, 1)
+    with pytest.raises(ValueError):
+        train_acx(
+            loader,
+            p=4,
+            device="cpu",
+            epochs=1,
+            val_data=(val_X, mu0, mu1),
+            verbose=False,
+        )


### PR DESCRIPTION
## Summary
- validate that validation tensors match `p` and each other
- test new mismatch behaviour

## Testing
- `ruff check .`
- `black --check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684f46c2e5c88324bb9d8d981fb1e1b0