### PR TITLE
Build and deploy docs

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,29 @@
+name: Docs
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  build-docs:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: "3.10"
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          pip install sphinx
+      - name: Build HTML
+        run: make -C docs html
+      - name: Deploy to GitHub Pages
+        if: github.ref == 'refs/heads/main'
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: docs/_build/html
+

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # crosslearner
 
-[![CI](https://github.com/your-username/crosslearner/actions/workflows/ci.yml/badge.svg)](https://github.com/your-username/crosslearner/actions/workflows/ci.yml) [![Docs](https://github.com/your-username/crosslearner/actions/workflows/docs.yml/badge.svg)](https://your-username.github.io/crosslearner/)
+[![CI](https://github.com/mattrss/crosslearner/actions/workflows/ci.yml/badge.svg)](https://github.com/mattrss/crosslearner/actions/workflows/ci.yml) [![Docs](https://github.com/mattrss/crosslearner/actions/workflows/docs.yml/badge.svg)](https://mattrss.github.io/crosslearner/)
 
 `crosslearner` implements the **Adversarial–Consistency X-learner (AC‑X)**, a variant of the X-learner that augments outcome models with an adversarial consistency term. The package is designed for reproducible research with numerous GAN tricks and benchmarking utilities.
 
@@ -171,7 +171,7 @@ behaviour:
 
 ## Documentation
 
-Hosted documentation is available at [https://your-username.github.io/crosslearner/](https://your-username.github.io/crosslearner/).
+Hosted documentation is available at [https://mattrss.github.io/crosslearner/](https://mattrss.github.io/crosslearner/).
 
 API documentation is built with Sphinx. Run the following commands to generate
 HTML docs in `docs/_build/html`:

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # crosslearner
 
+[![CI](https://github.com/your-username/crosslearner/actions/workflows/ci.yml/badge.svg)](https://github.com/your-username/crosslearner/actions/workflows/ci.yml) [![Docs](https://github.com/your-username/crosslearner/actions/workflows/docs.yml/badge.svg)](https://your-username.github.io/crosslearner/)
+
 `crosslearner` implements the **Adversarial–Consistency X-learner (AC‑X)**, a variant of the X-learner that augments outcome models with an adversarial consistency term. The package is designed for reproducible research with numerous GAN tricks and benchmarking utilities.
 
 ## Background
@@ -168,6 +170,8 @@ behaviour:
 - `plot_residuals` displays residuals against predictions.
 
 ## Documentation
+
+Hosted documentation is available at [https://your-username.github.io/crosslearner/](https://your-username.github.io/crosslearner/).
 
 API documentation is built with Sphinx. Run the following commands to generate
 HTML docs in `docs/_build/html`:


### PR DESCRIPTION
## Summary
- show CI and docs badges in the README
- mention hosted documentation
- build and deploy documentation from CI using GitHub Pages

## Testing
- `ruff check .`
- `black --check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684f47d3e7c883249683c62885908c83