### PR TITLE
Add dropout option to ACX model

### DIFF
--- a/crosslearner/models/acx.py
+++ b/crosslearner/models/acx.py
@@ -48,6 +48,8 @@ class MLP(nn.Module):
         hidden = tuple(hidden or [])
         act_fn = _get_activation(activation)
         dropout = float(dropout)
+        if not (0 <= dropout < 1):
+            raise ValueError(f"Dropout must be in the range [0, 1), but got {dropout}.")
         for h in hidden:
             layers += [nn.Linear(d, h), act_fn()]
             if dropout > 0:

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -1,4 +1,5 @@
 import torch
+import torch.nn as nn
 from crosslearner.models.acx import ACX
 
 
@@ -24,3 +25,10 @@ def test_acx_custom_architecture():
     X = torch.randn(4, 3)
     h, *_ = model(X)
     assert h.shape == (4, 32)
+
+
+def test_acx_dropout_layers():
+    model = ACX(p=2, phi_dropout=0.1, head_dropout=0.2, disc_dropout=0.3)
+    assert any(isinstance(m, nn.Dropout) for m in model.phi.net.modules())
+    assert any(isinstance(m, nn.Dropout) for m in model.mu0.net.modules())
+    assert any(isinstance(m, nn.Dropout) for m in model.disc.net.modules())


### PR DESCRIPTION
## Summary
- add dropout probability to `MLP`
- support dropout for ACX representation, head, and discriminator networks
- test that dropout layers are present

## Testing
- `ruff check .`
- `black --check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684f779d760c83249fd26c0846f910df