### PR TITLE
Add LR scheduler support in training

### DIFF
--- a/crosslearner/training/train_acx.py
+++ b/crosslearner/training/train_acx.py
@@ -184,11 +184,21 @@ def train_acx(
         if isinstance(lr_scheduler, str):
             name = lr_scheduler.lower()
             schedulers = {
-                "step": (torch.optim.lr_scheduler.StepLR, {"step_size": 1, "gamma": 0.9}),
-                "multistep": (torch.optim.lr_scheduler.MultiStepLR, {"milestones": [10, 20], "gamma": 0.1}),
-                "exponential": (torch.optim.lr_scheduler.ExponentialLR, {"gamma": 0.9}),
-                "cosine": (torch.optim.lr_scheduler.CosineAnnealingLR, {"T_max": 10}),
-                "plateau": (torch.optim.lr_scheduler.ReduceLROnPlateau, {"mode": "min", "factor": 0.1, "patience": 10}),
+                "step": (
+                    torch.optim.lr_scheduler.StepLR, 
+                        {"step_size": 1, "gamma": 0.9}),
+                "multistep": (
+                    torch.optim.lr_scheduler.MultiStepLR, 
+                    {"milestones": [10, 20], "gamma": 0.1}),
+                "exponential": (
+                    torch.optim.lr_scheduler.ExponentialLR, 
+                    {"gamma": 0.9}),
+                "cosine": (
+                    torch.optim.lr_scheduler.CosineAnnealingLR, 
+                    {"T_max": 10}),
+                "plateau": (
+                    torch.optim.lr_scheduler.ReduceLROnPlateau, 
+                    {"mode": "min", "factor": 0.1, "patience": 10}),
             }
             if name not in schedulers:
                 raise ValueError(f"Unknown lr scheduler '{lr_scheduler}'")

--- a/crosslearner/training/train_acx.py
+++ b/crosslearner/training/train_acx.py
@@ -184,15 +184,18 @@ def train_acx(
         if isinstance(lr_scheduler, str):
             name = lr_scheduler.lower()
             schedulers = {
-                "step": torch.optim.lr_scheduler.StepLR,
-                "multistep": torch.optim.lr_scheduler.MultiStepLR,
-                "exponential": torch.optim.lr_scheduler.ExponentialLR,
-                "cosine": torch.optim.lr_scheduler.CosineAnnealingLR,
-                "plateau": torch.optim.lr_scheduler.ReduceLROnPlateau,
+                "step": (torch.optim.lr_scheduler.StepLR, {"step_size": 1, "gamma": 0.9}),
+                "multistep": (torch.optim.lr_scheduler.MultiStepLR, {"milestones": [10, 20], "gamma": 0.1}),
+                "exponential": (torch.optim.lr_scheduler.ExponentialLR, {"gamma": 0.9}),
+                "cosine": (torch.optim.lr_scheduler.CosineAnnealingLR, {"T_max": 10}),
+                "plateau": (torch.optim.lr_scheduler.ReduceLROnPlateau, {"mode": "min", "factor": 0.1, "patience": 10}),
             }
             if name not in schedulers:
                 raise ValueError(f"Unknown lr scheduler '{lr_scheduler}'")
-            sched_cls = schedulers[name]
+            sched_cls, default_args = schedulers[name]
+            # Merge default arguments with user-supplied arguments
+            sched_g_kwargs = {**default_args, **sched_g_kwargs}
+            sched_d_kwargs = {**default_args, **sched_d_kwargs}
         else:
             sched_cls = lr_scheduler
         sched_g = sched_cls(opt_g, **sched_g_kwargs)

--- a/crosslearner/training/train_acx.py
+++ b/crosslearner/training/train_acx.py
@@ -185,20 +185,19 @@ def train_acx(
             name = lr_scheduler.lower()
             schedulers = {
                 "step": (
-                    torch.optim.lr_scheduler.StepLR, 
-                        {"step_size": 1, "gamma": 0.9}),
+                    torch.optim.lr_scheduler.StepLR,
+                    {"step_size": 1, "gamma": 0.9},
+                ),
                 "multistep": (
-                    torch.optim.lr_scheduler.MultiStepLR, 
-                    {"milestones": [10, 20], "gamma": 0.1}),
-                "exponential": (
-                    torch.optim.lr_scheduler.ExponentialLR, 
-                    {"gamma": 0.9}),
-                "cosine": (
-                    torch.optim.lr_scheduler.CosineAnnealingLR, 
-                    {"T_max": 10}),
+                    torch.optim.lr_scheduler.MultiStepLR,
+                    {"milestones": [10, 20], "gamma": 0.1},
+                ),
+                "exponential": (torch.optim.lr_scheduler.ExponentialLR, {"gamma": 0.9}),
+                "cosine": (torch.optim.lr_scheduler.CosineAnnealingLR, {"T_max": 10}),
                 "plateau": (
-                    torch.optim.lr_scheduler.ReduceLROnPlateau, 
-                    {"mode": "min", "factor": 0.1, "patience": 10}),
+                    torch.optim.lr_scheduler.ReduceLROnPlateau,
+                    {"mode": "min", "factor": 0.1, "patience": 10},
+                ),
             }
             if name not in schedulers:
                 raise ValueError(f"Unknown lr scheduler '{lr_scheduler}'")


### PR DESCRIPTION
## Summary
- add optional `lr_scheduler` argument in `train_acx`
- map common scheduler names to PyTorch implementations
- step schedulers each epoch
- test custom scheduler behaviour and error handling

## Testing
- `ruff check .`
- `black --check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684f7ed5511c8324bd569648182cee82