### PR TITLE
Add IPW & DR evaluation

### DIFF
--- a/crosslearner/evaluation/__init__.py
+++ b/crosslearner/evaluation/__init__.py
@@ -1,1 +1,21 @@
 """Evaluation metrics and helpers."""
+
+from .evaluate import evaluate, evaluate_ipw, evaluate_dr
+from .metrics import (
+    pehe,
+    policy_risk,
+    ate_error,
+    att_error,
+    bootstrap_ci,
+)
+
+__all__ = [
+    "evaluate",
+    "evaluate_ipw",
+    "evaluate_dr",
+    "pehe",
+    "policy_risk",
+    "ate_error",
+    "att_error",
+    "bootstrap_ci",
+]

--- a/crosslearner/evaluation/evaluate.py
+++ b/crosslearner/evaluation/evaluate.py
@@ -25,3 +25,71 @@ def evaluate(
         _, _, _, tau_hat = model(X)
     tau_true = mu1 - mu0
     return pehe(tau_hat, tau_true)
+
+
+def evaluate_ipw(
+    model: ACX,
+    X: torch.Tensor,
+    T: torch.Tensor,
+    Y: torch.Tensor,
+    propensity: torch.Tensor,
+) -> float:
+    """Return IPW tau risk for a dataset without counterfactuals.
+
+    The function computes an inverse-propensity weighted pseudo-outcome that is
+    unbiased for the true treatment effect and measures the PEHE between the
+    model predictions and this pseudo-outcome.
+
+    Args:
+        model: Trained ``ACX`` model.
+        X: Covariates ``(n, p)``.
+        T: Treatment indicators ``(n, 1)``.
+        Y: Observed outcomes ``(n, 1)``.
+        propensity: Propensity scores ``(n, 1)`` for receiving treatment.
+
+    Returns:
+        Estimated square-root PEHE using IPW pseudo-outcomes.
+    """
+
+    model.eval()
+    with torch.no_grad():
+        _, _, _, tau_hat = model(X)
+    pseudo = Y * (T / propensity - (1.0 - T) / (1.0 - propensity))
+    return pehe(tau_hat, pseudo)
+
+
+def evaluate_dr(
+    model: ACX,
+    X: torch.Tensor,
+    T: torch.Tensor,
+    Y: torch.Tensor,
+    propensity: torch.Tensor,
+) -> float:
+    """Return doubly-robust tau risk for observational datasets.
+
+    This estimator compares the model's CATE predictions against a doubly robust
+    pseudo-outcome constructed from outcome and propensity models. It reduces to
+    PEHE when true counterfactual outcomes are available but can be applied when
+    only observed outcomes are known.
+
+    Args:
+        model: Trained ``ACX`` model.
+        X: Covariates ``(n, p)``.
+        T: Treatment indicators ``(n, 1)``.
+        Y: Observed outcomes ``(n, 1)``.
+        propensity: Propensity scores ``(n, 1)`` for treatment.
+
+    Returns:
+        Estimated square-root PEHE using the doubly robust pseudo-outcomes.
+    """
+
+    model.eval()
+    with torch.no_grad():
+        _, mu0_hat, mu1_hat, tau_hat = model(X)
+    mu_hat = T * mu1_hat + (1.0 - T) * mu0_hat
+    pseudo = (
+        (T - propensity) / (propensity * (1.0 - propensity)) * (Y - mu_hat)
+        + mu1_hat
+        - mu0_hat
+    )
+    return pehe(tau_hat, pseudo)


### PR DESCRIPTION
## Summary
- implement `evaluate_ipw` and `evaluate_dr` for observational datasets
- expose new helpers in evaluation package
- test IPW and doubly-robust evaluation utilities

## Testing
- `ruff check .`
- `black --check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684f915835b48324bea71c86b3e53468