### PR TITLE
Implement propensity score estimator

### DIFF
--- a/crosslearner/evaluation/__init__.py
+++ b/crosslearner/evaluation/__init__.py
@@ -1,6 +1,7 @@
 """Evaluation metrics and helpers."""
 
 from .evaluate import evaluate, evaluate_ipw, evaluate_dr
+from .propensity import estimate_propensity
 from .metrics import (
     pehe,
     policy_risk,
@@ -18,4 +19,5 @@ __all__ = [
     "ate_error",
     "att_error",
     "bootstrap_ci",
+    "estimate_propensity",
 ]

--- a/crosslearner/evaluation/propensity.py
+++ b/crosslearner/evaluation/propensity.py
@@ -1,0 +1,34 @@
+"""Propensity score estimation helpers."""
+
+from __future__ import annotations
+
+import torch
+from sklearn.linear_model import LogisticRegression
+from sklearn.model_selection import KFold
+
+
+def estimate_propensity(
+    X: torch.Tensor, T: torch.Tensor, *, folds: int = 5, seed: int = 0
+) -> torch.Tensor:
+    """Return cross-fitted propensity scores via logistic regression.
+
+    Args:
+        X: Covariates ``(n, p)``.
+        T: Binary treatment indicators ``(n, 1)`` or ``(n,)``.
+        folds: Number of cross-fitting folds.
+        seed: Random seed controlling the CV split.
+
+    Returns:
+        Estimated propensity scores ``(n, 1)``.
+    """
+
+    X_np = X.detach().cpu().numpy()
+    T_np = T.view(-1).detach().cpu().numpy()
+    kf = KFold(n_splits=folds, shuffle=True, random_state=seed)
+    prop = torch.empty(X.shape[0], dtype=torch.float32)
+    for train_idx, test_idx in kf.split(X_np):
+        model = LogisticRegression(max_iter=1000)
+        model.fit(X_np[train_idx], T_np[train_idx])
+        pred = model.predict_proba(X_np[test_idx])[:, 1]
+        prop[test_idx] = torch.tensor(pred, dtype=torch.float32)
+    return prop.unsqueeze(-1)

--- a/crosslearner/evaluation/propensity.py
+++ b/crosslearner/evaluation/propensity.py
@@ -23,7 +23,7 @@ def estimate_propensity(
     """
 
     X_np = X.detach().cpu().numpy()
-    T_np = T.view(-1).detach().cpu().numpy()
+    T_np = T.view(-1).detach().cpu().numpy().astype(int)
     kf = KFold(n_splits=folds, shuffle=True, random_state=seed)
     prop = torch.empty(X.shape[0], dtype=torch.float32)
     for train_idx, test_idx in kf.split(X_np):

--- a/docs/api/crosslearner.evaluation.rst
+++ b/docs/api/crosslearner.evaluation.rst
@@ -20,6 +20,14 @@ crosslearner.evaluation.metrics module
    :show-inheritance:
    :undoc-members:
 
+crosslearner.evaluation.propensity module
+-----------------------------------------
+
+.. automodule:: crosslearner.evaluation.propensity
+   :members:
+   :show-inheritance:
+   :undoc-members:
+
 Module contents
 ---------------
 

--- a/tests/test_propensity.py
+++ b/tests/test_propensity.py
@@ -1,0 +1,14 @@
+import numpy as np
+import torch
+
+from crosslearner.evaluation.propensity import estimate_propensity
+
+
+def test_estimate_propensity_returns_probs():
+    rng = np.random.default_rng(0)
+    X = torch.tensor(rng.normal(size=(50, 3)), dtype=torch.float32)
+    T = torch.tensor(rng.integers(0, 2, size=(50, 1)), dtype=torch.float32)
+    prop = estimate_propensity(X, T, folds=3, seed=0)
+    assert prop.shape == (50, 1)
+    assert torch.all(prop >= 0) and torch.all(prop <= 1)
+    assert abs(prop.mean().item() - T.float().mean().item()) < 0.1


### PR DESCRIPTION
## Summary
- add `estimate_propensity` for cross-fitted logistic regression
- expose new helper via evaluation package
- document propensity module
- test propensity estimation

## Testing
- `ruff check .`
- `black --check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684f9c743d8883248f73ff481dc21013