### PR TITLE
Fix feature matching loss in training

### DIFF
--- a/crosslearner/models/acx.py
+++ b/crosslearner/models/acx.py
@@ -171,3 +171,11 @@ class ACX(nn.Module):
         """
 
         return self.disc(torch.cat([h, y, t], dim=1))
+
+    def disc_features(
+        self, h: torch.Tensor, y: torch.Tensor, t: torch.Tensor
+    ) -> torch.Tensor:
+        """Return discriminator features before the final linear layer."""
+
+        x = torch.cat([h, y, t], dim=1)
+        return self.disc.net[:-1](x)

--- a/crosslearner/training/train_acx.py
+++ b/crosslearner/training/train_acx.py
@@ -300,8 +300,9 @@ def train_acx(
             loss_g = alpha_out * loss_y + beta_cons * loss_cons + gamma_adv * loss_adv
 
             if feature_matching:
-                real_f = hb.detach()
-                fake_f = hb
+                with torch.no_grad():
+                    real_f = model.disc_features(hb.detach(), Yb, Tb)
+                fake_f = model.disc_features(hb, Ycf, Tb)
                 loss_fm = ((real_f.mean(0) - fake_f.mean(0)) ** 2).mean()
                 loss_g += eta_fm * loss_fm
 


### PR DESCRIPTION
## Summary
- expose discriminator hidden features in the ACX model
- use discriminator features for feature matching loss in `train_acx`

## Testing
- `ruff check .`
- `black --check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684fb04cbca48324a60ff8ff9edbe307