### PR TITLE
Handle unfitted baseline models

### DIFF
--- a/crosslearner/models/baselines/drlearner.py
+++ b/crosslearner/models/baselines/drlearner.py
@@ -36,10 +36,13 @@ class DRLearner:
         T = T.ravel()
         self.model_mu0.fit(X, Y.ravel())
         self.model_mu1.fit(X, Y.ravel())
-        self.model_e.fit(X, T)
+        if np.unique(T).size < 2:
+            e_hat = np.full_like(T, fill_value=T.mean(), dtype=float)
+        else:
+            self.model_e.fit(X, T)
+            e_hat = self.model_e.predict_proba(X)[:, 1]
         mu0_hat = self.model_mu0.predict(X)
         mu1_hat = self.model_mu1.predict(X)
-        e_hat = self.model_e.predict_proba(X)[:, 1]
         tau_tilde = (
             mu1_hat
             - mu0_hat

--- a/crosslearner/models/baselines/tlearner.py
+++ b/crosslearner/models/baselines/tlearner.py
@@ -18,6 +18,8 @@ class TLearner:
         self.model_t = MLPRegressor(hidden_layer_sizes=(64, 64), max_iter=100)
         self.model_c = MLPRegressor(hidden_layer_sizes=(64, 64), max_iter=100)
         self.p = p
+        self._fitted_t = False
+        self._fitted_c = False
 
     def fit(self, X: np.ndarray, T: np.ndarray, Y: np.ndarray) -> None:
         """Fit treatment and control models separately.
@@ -34,8 +36,14 @@ class TLearner:
         Yc = Y[T.squeeze() == 0]
         if len(Xt):
             self.model_t.fit(Xt, Yt.ravel())
+            self._fitted_t = True
+        else:
+            self._fitted_t = False
         if len(Xc):
             self.model_c.fit(Xc, Yc.ravel())
+            self._fitted_c = True
+        else:
+            self._fitted_c = False
 
     def predict_tau(self, X: np.ndarray) -> torch.Tensor:
         """Predict treatment effects.
@@ -47,6 +55,6 @@ class TLearner:
             Predicted treatment effects.
         """
 
-        mu1 = self.model_t.predict(X)
-        mu0 = self.model_c.predict(X)
+        mu1 = self.model_t.predict(X) if self._fitted_t else np.zeros(len(X))
+        mu0 = self.model_c.predict(X) if self._fitted_c else np.zeros(len(X))
         return torch.tensor(mu1 - mu0, dtype=torch.float32)

--- a/crosslearner/models/baselines/xlearner.py
+++ b/crosslearner/models/baselines/xlearner.py
@@ -21,6 +21,8 @@ class XLearner:
         self.model_tau_t = MLPRegressor(hidden_layer_sizes=(64, 64), max_iter=100)
         self.model_tau_c = MLPRegressor(hidden_layer_sizes=(64, 64), max_iter=100)
         self.p = p
+        self._fitted_tau_t = False
+        self._fitted_tau_c = False
 
     def fit(self, X: np.ndarray, T: np.ndarray, Y: np.ndarray) -> None:
         """Fit the base learners and pseudo-outcome regressors.
@@ -36,14 +38,30 @@ class XLearner:
         Yt = Y[T.squeeze() == 1]
         Xc = X[T.squeeze() == 0]
         Yc = Y[T.squeeze() == 0]
-        mu0_t = self.t.model_c.predict(Xt) if len(Xt) else np.zeros(len(Xt))
+
+        mu0_t = (
+            self.t.model_c.predict(Xt)
+            if self.t._fitted_c and len(Xt)
+            else np.zeros(len(Xt))
+        )
         d1 = Yt.ravel() - mu0_t
-        mu1_c = self.t.model_t.predict(Xc) if len(Xc) else np.zeros(len(Xc))
+        mu1_c = (
+            self.t.model_t.predict(Xc)
+            if self.t._fitted_t and len(Xc)
+            else np.zeros(len(Xc))
+        )
         d0 = mu1_c - Yc.ravel()
+
         if len(Xt):
             self.model_tau_t.fit(Xt, d1)
+            self._fitted_tau_t = True
+        else:
+            self._fitted_tau_t = False
         if len(Xc):
             self.model_tau_c.fit(Xc, d0)
+            self._fitted_tau_c = True
+        else:
+            self._fitted_tau_c = False
         self.prop = T.mean()
 
     def predict_tau(self, X: np.ndarray) -> torch.Tensor:
@@ -56,8 +74,8 @@ class XLearner:
             Tensor of predicted treatment effects.
         """
 
-        tau_t = self.model_tau_t.predict(X)
-        tau_c = self.model_tau_c.predict(X)
+        tau_t = self.model_tau_t.predict(X) if self._fitted_tau_t else np.zeros(len(X))
+        tau_c = self.model_tau_c.predict(X) if self._fitted_tau_c else np.zeros(len(X))
         return torch.tensor(
             (1 - self.prop) * tau_t + self.prop * tau_c, dtype=torch.float32
         )

--- a/crosslearner/models/baselines/xlearner.py
+++ b/crosslearner/models/baselines/xlearner.py
@@ -23,6 +23,7 @@ class XLearner:
         self.p = p
         self._fitted_tau_t = False
         self._fitted_tau_c = False
+        self.prop = 0.0
 
     def fit(self, X: np.ndarray, T: np.ndarray, Y: np.ndarray) -> None:
         """Fit the base learners and pseudo-outcome regressors.

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -53,3 +53,21 @@ def test_drlearner_fit_predict():
     model.fit(X, T, Y)
     tau = model.predict_tau(X)
     assert tau.shape == (X.shape[0],)
+
+
+def test_tlearner_single_group():
+    X, T, Y = _make_data()
+    T[:] = 1
+    model = TLearner(p=X.shape[1])
+    model.fit(X, T, Y)
+    tau = model.predict_tau(X)
+    assert tau.shape == (X.shape[0],)
+
+
+def test_xlearner_single_group():
+    X, T, Y = _make_data()
+    T[:] = 0
+    model = XLearner(p=X.shape[1])
+    model.fit(X, T, Y)
+    tau = model.predict_tau(X)
+    assert tau.shape == (X.shape[0],)


### PR DESCRIPTION
## Summary
- add guards in TLearner and XLearner for cases with only one treatment group
- fall back to constant propensity in DRLearner
- test baseline learners on degenerate datasets

## Testing
- `ruff check .`
- `black --check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684fb5cc45d48324a6fd623cf84bfe26