### PR TITLE
Fix warm start loss tracking

### DIFF
--- a/crosslearner/training/train_acx.py
+++ b/crosslearner/training/train_acx.py
@@ -236,6 +236,9 @@ def train_acx(
                 opt_g.zero_grad()
                 loss_y.backward()
                 opt_g.step()
+                loss_y_sum += loss_y.item()
+                loss_g_sum += loss_y.item()
+                batch_count += 1
                 continue
 
             # ------------- discriminator update -------------------------

--- a/tests/test_training.py
+++ b/tests/test_training.py
@@ -172,6 +172,21 @@ def test_train_acx_custom_scheduler(monkeypatch):
     assert steps["count"] == 2
 
 
+def test_warm_start_logs_losses():
+    loader, _ = get_toy_dataloader(batch_size=8, n=32, p=4)
+    _, history = train_acx(
+        loader,
+        p=4,
+        device="cpu",
+        epochs=2,
+        warm_start=1,
+        return_history=True,
+        verbose=False,
+    )
+    assert history[0].loss_y > 0
+    assert history[0].loss_g > 0
+
+
 def test_train_acx_1d_targets():
     X = torch.randn(16, 4)
     T = torch.randint(0, 2, (16,))


### PR DESCRIPTION
## Summary
- log warm-start losses so history reflects early epochs
- test that warm-start epochs record generator loss

## Testing
- `ruff check .`
- `black --check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684fbc8ce4dc8324b3fafeb09baf433a