### PR TITLE
Fix DRLearner outcome training

### DIFF
--- a/crosslearner/models/baselines/drlearner.py
+++ b/crosslearner/models/baselines/drlearner.py
@@ -34,8 +34,18 @@ class DRLearner:
         """
 
         T = T.ravel()
-        self.model_mu0.fit(X, Y.ravel())
-        self.model_mu1.fit(X, Y.ravel())
+        mask_t = T == 1
+        mask_c = ~mask_t
+
+        # fit outcome models on their respective subsets
+        if mask_c.any():
+            self.model_mu0.fit(X[mask_c], Y[mask_c].ravel())
+        else:
+            self.model_mu0.fit(X, Y.ravel())
+        if mask_t.any():
+            self.model_mu1.fit(X[mask_t], Y[mask_t].ravel())
+        else:
+            self.model_mu1.fit(X, Y.ravel())
         if np.unique(T).size < 2:
             e_hat = np.full_like(T, fill_value=T.mean(), dtype=float)
         else:

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -71,3 +71,14 @@ def test_xlearner_single_group():
     model.fit(X, T, Y)
     tau = model.predict_tau(X)
     assert tau.shape == (X.shape[0],)
+
+
+def test_drlearner_learns_effect():
+    rng = np.random.default_rng(0)
+    X = rng.standard_normal((100, 3))
+    T = rng.integers(0, 2, size=(100, 1))
+    Y = X[:, :1] + T  # constant treatment effect of 1
+    model = DRLearner(p=X.shape[1])
+    model.fit(X, T, Y)
+    tau = model.predict_tau(X)
+    assert abs(tau.mean().item() - 1.0) < 0.5


### PR DESCRIPTION
## Summary
- train DRLearner outcome models on the correct treatment subsets
- add regression test verifying DRLearner learns a constant effect

## Testing
- `ruff check .`
- `black --check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684fbfb8d06c8324850473baa498b68a