### PR TITLE
Fix train mode after evaluation

### DIFF
--- a/crosslearner/training/train_acx.py
+++ b/crosslearner/training/train_acx.py
@@ -220,6 +220,7 @@ def train_acx(
     freeze_d = False
 
     for epoch in range(epochs):
+        model.train()
         loss_d_sum = loss_g_sum = 0.0
         loss_y_sum = loss_cons_sum = loss_adv_sum = 0.0
         batch_count = 0


### PR DESCRIPTION
## Summary
- fix ACX training loop to resume `train()` mode after validation

## Testing
- `ruff check crosslearner/training/train_acx.py`
- `black --check crosslearner/training/train_acx.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684fbfb0563c8324a00104a7e806df7a