### PR TITLE
Improve device handling in evaluation utilities

### DIFF
--- a/crosslearner/evaluation/evaluate.py
+++ b/crosslearner/evaluation/evaluate.py
@@ -20,6 +20,11 @@ def evaluate(
         The square-root PEHE value.
     """
 
+    device = next(model.parameters()).device
+    X = X.to(device)
+    mu0 = mu0.to(device)
+    mu1 = mu1.to(device)
+
     model.eval()
     with torch.no_grad():
         _, _, _, tau_hat = model(X)
@@ -50,6 +55,12 @@ def evaluate_ipw(
     Returns:
         Estimated square-root PEHE using IPW pseudo-outcomes.
     """
+
+    device = next(model.parameters()).device
+    X = X.to(device)
+    T = T.to(device)
+    Y = Y.to(device)
+    propensity = propensity.to(device)
 
     model.eval()
     with torch.no_grad():
@@ -82,6 +93,12 @@ def evaluate_dr(
     Returns:
         Estimated square-root PEHE using the doubly robust pseudo-outcomes.
     """
+
+    device = next(model.parameters()).device
+    X = X.to(device)
+    T = T.to(device)
+    Y = Y.to(device)
+    propensity = propensity.to(device)
 
     model.eval()
     with torch.no_grad():

--- a/crosslearner/visualization.py
+++ b/crosslearner/visualization.py
@@ -39,6 +39,11 @@ def scatter_tau(model: ACX, X: torch.Tensor, mu0: torch.Tensor, mu1: torch.Tenso
     Returns:
         Matplotlib figure with a scatter plot of true vs predicted ``tau``.
     """
+    device = next(model.parameters()).device
+    X = X.to(device)
+    mu0 = mu0.to(device)
+    mu1 = mu1.to(device)
+
     model.eval()
     with torch.no_grad():
         _, _, _, tau_hat = model(X)

--- a/tests/test_evaluation.py
+++ b/tests/test_evaluation.py
@@ -1,4 +1,5 @@
 import torch
+import pytest
 
 from crosslearner.evaluation.metrics import pehe
 from crosslearner.evaluation.evaluate import evaluate, evaluate_ipw, evaluate_dr
@@ -53,3 +54,14 @@ def test_evaluate_dr_zero_error():
     propensity = torch.full((4, 1), 0.5)
     metric = evaluate_dr(model, X, T, Y, propensity)
     assert metric < 1e-6
+
+
+def test_evaluate_device_mismatch():
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA not available")
+    model = ACX(p=2).cuda()
+    X = torch.zeros(2, 2)
+    mu0 = torch.zeros(2, 1)
+    mu1 = torch.ones(2, 1)
+    metric = evaluate(model, X, mu0, mu1)
+    assert isinstance(metric, float)

--- a/tests/test_visualization.py
+++ b/tests/test_visualization.py
@@ -1,5 +1,6 @@
 import torch
 import matplotlib
+import pytest
 
 matplotlib.use("Agg")
 
@@ -32,6 +33,18 @@ def test_scatter_tau_returns_figure():
     X = torch.randn(4, 3)
     mu0 = torch.zeros(4, 1)
     mu1 = torch.ones(4, 1)
+    fig = scatter_tau(model, X, mu0, mu1)
+    assert fig is not None
+    matplotlib.pyplot.close(fig)
+
+
+def test_scatter_tau_device_mismatch():
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA not available")
+    model = ACX(p=3).cuda()
+    X = torch.randn(2, 3)
+    mu0 = torch.zeros(2, 1)
+    mu1 = torch.ones(2, 1)
     fig = scatter_tau(model, X, mu0, mu1)
     assert fig is not None
     matplotlib.pyplot.close(fig)


### PR DESCRIPTION
## Summary
- ensure evaluation helpers automatically move inputs to the model's device
- do the same when plotting `tau` predictions
- test that evaluation and plotting succeed when tensors are on a different device

## Testing
- `ruff check .`
- `black --check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684fc4ff31b88324873faa420322d0bf