### PR TITLE
Fix dtype issues for int datasets

### DIFF
--- a/crosslearner/training/train_acx.py
+++ b/crosslearner/training/train_acx.py
@@ -231,6 +231,8 @@ def train_acx(
                 Tb = Tb.unsqueeze(-1)
             if Yb.ndim == 1:
                 Yb = Yb.unsqueeze(-1)
+            Tb = Tb.float()
+            Yb = Yb.float()
             hb, m0, m1, tau = model(Xb)
             hb_det = hb.detach()
             m0_det = m0.detach()


### PR DESCRIPTION
## Summary
- cast treatment and outcome batches to float so BCE/MSE work with integer datasets

## Testing
- `ruff check .`
- `black --check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684fce0e046c8324b951243f26df409f