### PR TITLE
Improve documentation readability

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![CI](https://github.com/mattrss/crosslearner/actions/workflows/ci.yml/badge.svg)](https://github.com/mattrss/crosslearner/actions/workflows/ci.yml) [![Docs](https://github.com/mattrss/crosslearner/actions/workflows/docs.yml/badge.svg)](https://mattrss.github.io/crosslearner/)
 
-`crosslearner` implements the **Adversarial–Consistency X-learner (AC‑X)**, a variant of the X-learner that augments outcome models with an adversarial consistency term. The package is designed for reproducible research with numerous GAN tricks and benchmarking utilities.
+`crosslearner` implements the **Adversarial–Consistency X-learner (AC‑X)**. This variant of the X‑learner augments outcome models with an adversarial consistency term. The library is geared towards reproducible research and ships with many GAN tricks and benchmarking utilities.
 
 ## Background
 
@@ -31,13 +31,13 @@ Install from source:
 pip install .
 ```
 
-Run a toy training loop:
+To run a quick training loop:
 
 ```bash
 crosslearner-train
 ```
 
-The script trains an AC‑X model on a small synthetic dataset and prints the final $\sqrt{\mathrm{PEHE}}$ metric. Loss histories are optionally logged to TensorBoard for experiment tracking.
+This command trains an AC‑X model on a small synthetic dataset and prints the final $\sqrt{\mathrm{PEHE}}$ metric. Loss histories are optionally logged to TensorBoard for experiment tracking.
 
 ## Benchmarking
 
@@ -47,7 +47,7 @@ To benchmark across available datasets:
 crosslearner-benchmarks all --replicates 1 --epochs 1
 ```
 
-The command trains a small model on several built-in datasets and reports the
+This command trains a small model on several built-in datasets and reports the
 mean $\sqrt{\mathrm{PEHE}}$ for each task. In this environment the benchmark
 uses the ``toy``, ``complex``, ``iris``, ``ihdp`` and ``confounded`` datasets.
 

--- a/docs/hyperparameter_sweeps.rst
+++ b/docs/hyperparameter_sweeps.rst
@@ -1,13 +1,12 @@
 Hyperparameter Sweeps with Optuna
 ================================
 
-`optuna <https://optuna.org/>`_ provides a convenient interface for tuning
-training parameters. The basic idea is to sample different configurations,
-train an AC-X model for each and keep the best one according to a validation
-metric.
+`optuna <https://optuna.org/>`_ is a lightweight library for automated
+hyperparameter search. It repeatedly samples configurations, trains an AC-X
+model and keeps the one with the best validation metric.
 
-Below is a minimal example that sweeps a few hyperparameters and optimises the
-validation :math:`\sqrt{\mathrm{PEHE}}`.
+The snippet below sweeps a few hyperparameters and minimises the validation
+:math:`\sqrt{\mathrm{PEHE}}`.
 
 .. code-block:: python
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,14 +1,9 @@
-.. crosslearner documentation master file, created by
-   sphinx-quickstart on Sun Jun 15 00:09:14 2025.
-   You can adapt this file completely to your liking, but it should at least
-   contain the root `toctree` directive.
-
 crosslearner documentation
 ==========================
 
-Add your content using ``reStructuredText`` syntax. See the
-`reStructuredText <https://www.sphinx-doc.org/en/master/usage/restructuredtext/index.html>`_
-documentation for details.
+This manual collects theoretical background, usage examples and the complete
+API reference for the AC‑X implementation. Follow the links below to learn about
+the training procedure, hyperparameter sweeps and available modules.
 
 
 .. toctree::


### PR DESCRIPTION
## Summary
- make README introductory paragraph friendlier
- clarify quick start instructions and benchmarking description
- replace Sphinx boilerplate with short introduction
- improve wording in the Optuna sweep tutorial

## Testing
- `ruff check .`
- `black --check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684fd4d668848324a04cde87c71899d0