### PR TITLE
Add residual connections to MLP

### DIFF
--- a/crosslearner/training/train_acx.py
+++ b/crosslearner/training/train_acx.py
@@ -20,6 +20,7 @@ def train_acx(
     head_layers: Iterable[int] | None = (64,),
     disc_layers: Iterable[int] | None = (64,),
     activation: str | Callable[[], nn.Module] = "relu",
+    residual: bool = False,
     device: Optional[str] = None,
     epochs: int = 30,
     alpha_out: float = 1.0,
@@ -62,6 +63,7 @@ def train_acx(
         head_layers: Hidden layers for the outcome and effect heads.
         disc_layers: Hidden layers for the discriminator.
         activation: Activation function used in all networks.
+        residual: Enable residual connections in all MLPs.
         device: Device string, defaults to CUDA if available.
         epochs: Number of training epochs.
         alpha_out: Weight of the outcome loss.
@@ -145,6 +147,7 @@ def train_acx(
         head_layers=head_layers,
         disc_layers=disc_layers,
         activation=activation_fn,
+        residual=residual,
     ).to(device)
     if spectral_norm:
         for m in model.modules():

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -32,3 +32,10 @@ def test_acx_dropout_layers():
     assert any(isinstance(m, nn.Dropout) for m in model.phi.net.modules())
     assert any(isinstance(m, nn.Dropout) for m in model.mu0.net.modules())
     assert any(isinstance(m, nn.Dropout) for m in model.disc.net.modules())
+
+
+def test_acx_residual_option():
+    model = ACX(p=3, residual=True)
+    X = torch.randn(2, 3)
+    h, _, _, _ = model(X)
+    assert h.shape[0] == 2

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,4 +1,5 @@
 import pytest
+import torch
 import torch.nn as nn
 
 from crosslearner.models.acx import MLP, _get_activation
@@ -19,3 +20,10 @@ def test_mlp_dropout_range_errors():
         MLP(4, 2, dropout=-0.1)
     with pytest.raises(ValueError):
         MLP(4, 2, dropout=1.0)
+
+
+def test_mlp_residual_forward():
+    mlp = MLP(4, 4, hidden=(4,), residual=True)
+    x = torch.randn(2, 4)
+    y = mlp(x)
+    assert y.shape == (2, 4)


### PR DESCRIPTION
## Summary
- support residual skip connections in the `MLP` used by ACX
- expose the option in `ACX` and `train_acx`
- test residual forward paths

## Testing
- `ruff check .`
- `black --check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684fe439f3ec83248e6d9d48353b3f5c