### PR TITLE
Expose dropout options in training

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ cross-validated $\sqrt{\mathrm{PEHE}}$ across the built-in synthetic datasets:
 - `crosslearner/evaluation/` – metrics such as PEHE.
 - `crosslearner/configs/` – YAML configs with hyper‑parameters.
 
-The training code exposes options for Wasserstein loss with gradient penalty, spectral normalisation, feature matching, instance noise, gradient reversal and two‑time‑scale update rule (TTUR). Early stopping on validation $\sqrt{\mathrm{PEHE}}$ is also provided.
+The training code exposes options for Wasserstein loss with gradient penalty, spectral normalisation, feature matching, instance noise, gradient reversal and two‑time‑scale update rule (TTUR). Early stopping on validation $\sqrt{\mathrm{PEHE}}$ is also provided. Dropout can be configured separately for the representation, head and discriminator networks.
 
 Use the config file as a starting point for your own experiments on IHDP, ACIC or other datasets.
 

--- a/crosslearner/configs/default.yaml
+++ b/crosslearner/configs/default.yaml
@@ -6,6 +6,9 @@ phi_layers: [128]
 head_layers: [64]
 disc_layers: [64]
 activation: relu
+phi_dropout: 0.0
+head_dropout: 0.0
+disc_dropout: 0.0
 lr_g: 0.001
 lr_d: 0.001
 optimizer: adam

--- a/crosslearner/training/train_acx.py
+++ b/crosslearner/training/train_acx.py
@@ -20,6 +20,9 @@ def train_acx(
     head_layers: Iterable[int] | None = (64,),
     disc_layers: Iterable[int] | None = (64,),
     activation: str | Callable[[], nn.Module] = "relu",
+    phi_dropout: float = 0.0,
+    head_dropout: float = 0.0,
+    disc_dropout: float = 0.0,
     residual: bool = False,
     device: Optional[str] = None,
     epochs: int = 30,
@@ -63,6 +66,9 @@ def train_acx(
         head_layers: Hidden layers for the outcome and effect heads.
         disc_layers: Hidden layers for the discriminator.
         activation: Activation function used in all networks.
+        phi_dropout: Dropout probability for the representation MLP.
+        head_dropout: Dropout probability for the outcome and effect heads.
+        disc_dropout: Dropout probability for the discriminator.
         residual: Enable residual connections in all MLPs.
         device: Device string, defaults to CUDA if available.
         epochs: Number of training epochs.
@@ -147,6 +153,9 @@ def train_acx(
         head_layers=head_layers,
         disc_layers=disc_layers,
         activation=activation_fn,
+        phi_dropout=phi_dropout,
+        head_dropout=head_dropout,
+        disc_dropout=disc_dropout,
         residual=residual,
     ).to(device)
     if spectral_norm:

--- a/tests/test_training.py
+++ b/tests/test_training.py
@@ -5,6 +5,7 @@ from crosslearner.datasets.toy import get_toy_dataloader
 from crosslearner.evaluation.evaluate import evaluate
 from crosslearner.models.acx import ACX
 from crosslearner.training.train_acx import train_acx
+import torch.nn as nn
 import pytest
 from torch.utils.data import DataLoader, TensorDataset
 
@@ -253,3 +254,20 @@ def test_train_acx_negative_weight_clip():
     loader, _ = get_toy_dataloader(batch_size=4, n=8, p=4)
     with pytest.raises(ValueError):
         train_acx(loader, p=4, device="cpu", epochs=1, weight_clip=-0.1, verbose=False)
+
+
+def test_train_acx_dropout_options():
+    loader, _ = get_toy_dataloader(batch_size=4, n=8, p=4)
+    model = train_acx(
+        loader,
+        p=4,
+        device="cpu",
+        epochs=1,
+        phi_dropout=0.1,
+        head_dropout=0.1,
+        disc_dropout=0.1,
+        verbose=False,
+    )
+    assert any(isinstance(m, nn.Dropout) for m in model.phi.net.modules())
+    assert any(isinstance(m, nn.Dropout) for m in model.mu0.net.modules())
+    assert any(isinstance(m, nn.Dropout) for m in model.disc.net.modules())


### PR DESCRIPTION
## Summary
- allow `train_acx` to specify phi/head/discriminator dropout
- document dropout usage and update default config
- mention dropout in README
- test dropout options pass through `train_acx`

## Testing
- `ruff check .`
- `black --check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684fed10ff508324b81617d580b6a14d