### PR TITLE
Fix MLP forward logic

### DIFF
--- a/crosslearner/models/acx.py
+++ b/crosslearner/models/acx.py
@@ -90,14 +90,17 @@ class MLP(nn.Module):
             Tensor with shape ``(batch, out_dim)``.
         """
 
-        h = x
-        for block in self.blocks:
-            z = block(h)
-            if self.residual and z.shape == h.shape:
-                h = z + h
-            else:
-                h = z
-        return self.out(h)
+        if self.residual:
+            h = x
+            for block in self.blocks:
+                z = block(h)
+                if z.shape == h.shape:
+                    h = z + h
+                else:
+                    h = z
+            return self.out(h)
+        else:
+            return self.net(x)
 
 
 class ACX(nn.Module):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -27,3 +27,11 @@ def test_mlp_residual_forward():
     x = torch.randn(2, 4)
     y = mlp(x)
     assert y.shape == (2, 4)
+
+
+def test_mlp_forward_matches_sequential_without_residual():
+    mlp = MLP(3, 2, hidden=(5,), residual=False)
+    x = torch.randn(4, 3)
+    y_seq = mlp.net(x)
+    y = mlp(x)
+    assert torch.allclose(y, y_seq)


### PR DESCRIPTION
## Summary
- fix residual logic in `MLP.forward`
- add regression test to ensure non-residual mode matches sequential network

## Testing
- `ruff check .`
- `black --check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68509b36ad8083248f1e1ed3fe457bed