### PR TITLE
Refactor activation handling

### DIFF
--- a/crosslearner/training/train_acx.py
+++ b/crosslearner/training/train_acx.py
@@ -8,7 +8,7 @@ from sklearn.model_selection import StratifiedKFold
 from crosslearner.training.history import EpochStats, History
 from crosslearner.evaluation.evaluate import evaluate
 
-from crosslearner.models.acx import ACX
+from crosslearner.models.acx import ACX, _get_activation
 from crosslearner.training.grl import grad_reverse
 
 
@@ -230,20 +230,7 @@ def train_acx(
             f"Input dimension mismatch: dataset has {feat_dim} features but p={p}"
         )
 
-    if isinstance(activation, str):
-        act_name = activation.lower()
-        activations = {
-            "relu": nn.ReLU,
-            "tanh": nn.Tanh,
-            "elu": nn.ELU,
-            "gelu": nn.GELU,
-            "leakyrelu": nn.LeakyReLU,
-        }
-        if act_name not in activations:
-            raise ValueError(f"Unknown activation '{activation}'")
-        activation_fn = activations[act_name]
-    else:
-        activation_fn = activation
+    activation_fn = _get_activation(activation)
 
     model = ACX(
         p,

--- a/tests/test_training.py
+++ b/tests/test_training.py
@@ -250,6 +250,14 @@ def test_train_acx_invalid_activation():
         train_acx(loader, p=4, device="cpu", epochs=1, activation="bad", verbose=False)
 
 
+def test_train_acx_activation_instance():
+    loader, _ = get_toy_dataloader(batch_size=4, n=8, p=4)
+    with pytest.raises(TypeError):
+        train_acx(
+            loader, p=4, device="cpu", epochs=1, activation=nn.ReLU(), verbose=False
+        )
+
+
 def test_train_acx_invalid_optimizer():
     loader, _ = get_toy_dataloader(batch_size=4, n=8, p=4)
     with pytest.raises(ValueError):


### PR DESCRIPTION
## Summary
- reuse `_get_activation` in `train_acx`
- test that `train_acx` rejects activation instances

## Testing
- `ruff check .`
- `black .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68509b6489008324909b6dbb6f20a397