### PR TITLE
Fix gradient handling for warm start

### DIFF
--- a/crosslearner/training/train_acx.py
+++ b/crosslearner/training/train_acx.py
@@ -355,10 +355,14 @@ def train_acx(
             m0_det = m0.detach()
             m1_det = m1.detach()
 
+            # warm start: train generator without adversary
             if warm_start > 0 and epoch < warm_start:
                 loss_y = mse(torch.where(Tb.bool(), m1, m0), Yb)
                 opt_g.zero_grad()
                 loss_y.backward()
+                # clip before stepping to avoid exploding gradients
+                if grad_clip:
+                    nn.utils.clip_grad_norm_(model.parameters(), grad_clip)
                 opt_g.step()
                 loss_y_sum += loss_y.item()
                 loss_g_sum += loss_y.item()

--- a/tests/test_training.py
+++ b/tests/test_training.py
@@ -208,6 +208,20 @@ def test_warm_start_logs_losses():
     assert history[0].loss_g > 0
 
 
+def test_warm_start_grad_clip():
+    loader, _ = get_toy_dataloader(batch_size=8, n=32, p=4)
+    model = train_acx(
+        loader,
+        p=4,
+        device="cpu",
+        epochs=2,
+        warm_start=1,
+        grad_clip=1.0,
+        verbose=False,
+    )
+    assert isinstance(model, ACX)
+
+
 def test_train_acx_1d_targets():
     X = torch.randn(16, 4)
     T = torch.randint(0, 2, (16,))


### PR DESCRIPTION
## Summary
- clip generator gradients during warm start
- test warm start with gradient clipping

## Testing
- `ruff check .`
- `black --check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68509b9420708324b07e5d59c09c41a1