### PR TITLE
Improve discriminator step memory

### DIFF
--- a/crosslearner/training/train_acx.py
+++ b/crosslearner/training/train_acx.py
@@ -350,12 +350,11 @@ def train_acx(
                 Yb = Yb.unsqueeze(-1)
             Tb = Tb.float()
             Yb = Yb.float()
-            hb, m0, m1, tau = model(Xb)
-            hb_det = hb.detach()
-            m0_det = m0.detach()
-            m1_det = m1.detach()
+            with torch.no_grad():
+                hb_det, m0_det, m1_det, _ = model(Xb)
 
             if warm_start > 0 and epoch < warm_start:
+                hb, m0, m1, _ = model(Xb)
                 loss_y = mse(torch.where(Tb.bool(), m1, m0), Yb)
                 opt_g.zero_grad()
                 loss_y.backward()


### PR DESCRIPTION
## Summary
- avoid storing generator computation graph when updating discriminator

## Testing
- `ruff check .`
- `black --check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68509f026d30832484f4cc3bd24e3900