### PR TITLE
Add comprehensive seed setting utility

### DIFF
--- a/crosslearner/__init__.py
+++ b/crosslearner/__init__.py
@@ -5,6 +5,7 @@ from .training.train_acx import train_acx
 from .training.history import EpochStats, History
 from .evaluation.evaluate import evaluate
 from .experiments import ExperimentManager, cross_validate_acx
+from .utils import set_seed
 from .visualization import (
     plot_losses,
     scatter_tau,
@@ -29,4 +30,5 @@ __all__ = [
     "plot_residuals",
     "ExperimentManager",
     "cross_validate_acx",
+    "set_seed",
 ]

--- a/crosslearner/__main__.py
+++ b/crosslearner/__main__.py
@@ -2,6 +2,8 @@
 
 import torch
 
+from crosslearner.utils import set_seed
+
 from crosslearner.datasets.toy import get_toy_dataloader
 from crosslearner.training.train_acx import train_acx
 from crosslearner.evaluation.evaluate import evaluate
@@ -9,6 +11,7 @@ from crosslearner.evaluation.evaluate import evaluate
 
 def main() -> None:
     """Run the toy training loop from the command line."""
+    set_seed(0)
     loader, (mu0, mu1) = get_toy_dataloader()
     device = "cuda" if torch.cuda.is_available() else "cpu"
     model = train_acx(loader, p=10, device=device)

--- a/crosslearner/benchmarks/run_benchmarks.py
+++ b/crosslearner/benchmarks/run_benchmarks.py
@@ -25,6 +25,7 @@ from crosslearner.evaluation.metrics import (
     att_error,
     bootstrap_ci,
 )
+from crosslearner.utils import set_seed
 
 
 def load_external_iris(batch_size: int = 256, seed: int | None = None):
@@ -77,6 +78,7 @@ def run(dataset: str, replicates: int = 3, epochs: int = 30) -> List[Dict[str, f
     """
     results: List[Dict[str, float]] = []
     for seed in range(replicates):
+        set_seed(seed)
         if dataset == "toy":
             loader, (mu0, mu1) = get_toy_dataloader()
             p = 10
@@ -129,7 +131,7 @@ def run(dataset: str, replicates: int = 3, epochs: int = 30) -> List[Dict[str, f
             return [v for _, v in summary]
         else:
             raise ValueError(f"Unknown dataset {dataset}")
-        model = train_acx(loader, p=p, epochs=epochs)
+        model = train_acx(loader, p=p, epochs=epochs, seed=seed)
         X = torch.cat([b[0] for b in loader])
         T_all = torch.cat([b[1] for b in loader])
         mu0_all = mu0

--- a/crosslearner/experiments/manager.py
+++ b/crosslearner/experiments/manager.py
@@ -9,6 +9,8 @@ import torch
 from torch.utils.data import DataLoader, TensorDataset
 from sklearn.model_selection import KFold
 
+from ..utils import set_seed
+
 from ..training.train_acx import train_acx
 from ..evaluation.evaluate import evaluate
 
@@ -46,6 +48,7 @@ def cross_validate_acx(
         Mean validation :math:`\sqrt{\mathrm{PEHE}}` across folds.
     """
     device = device or ("cuda" if torch.cuda.is_available() else "cpu")
+    set_seed(seed)
     dataset: TensorDataset = loader.dataset  # type: ignore[arg-type]
     X, T, Y = dataset.tensors
     kf = KFold(n_splits=folds, shuffle=True, random_state=seed)
@@ -66,6 +69,7 @@ def cross_validate_acx(
             train_loader,
             p,
             device=device,
+            seed=seed,
             val_data=val_data,
             tensorboard_logdir=fold_dir,
             **train_kwargs,

--- a/crosslearner/training/train_acx.py
+++ b/crosslearner/training/train_acx.py
@@ -7,6 +7,7 @@ from sklearn.model_selection import StratifiedKFold
 
 from crosslearner.training.history import EpochStats, History
 from crosslearner.evaluation.evaluate import evaluate
+from crosslearner.utils import set_seed
 
 from crosslearner.models.acx import ACX
 from crosslearner.training.grl import grad_reverse
@@ -44,7 +45,7 @@ def _estimate_nuisances(
     bce = nn.BCELoss()
     mse = nn.MSELoss()
 
-    torch.manual_seed(seed)
+    set_seed(seed)
     kfold = StratifiedKFold(folds, shuffle=True, random_state=seed)
     e_hat = torch.empty_like(T, device=device)
     mu0_hat = torch.empty_like(Y, device=device)
@@ -119,6 +120,7 @@ def train_acx(
     disc_dropout: float = 0.0,
     residual: bool = False,
     device: Optional[str] = None,
+    seed: int | None = None,
     epochs: int = 30,
     alpha_out: float = 1.0,
     beta_cons: float = 10.0,
@@ -167,6 +169,7 @@ def train_acx(
         disc_dropout: Dropout probability for the discriminator.
         residual: Enable residual connections in all MLPs.
         device: Device string, defaults to CUDA if available.
+        seed: Optional random seed for reproducibility.
         epochs: Number of training epochs.
         alpha_out: Weight of the outcome loss.
         beta_cons: Weight of the consistency term.
@@ -212,6 +215,8 @@ def train_acx(
         ``return_history`` is ``True``.
     """
     device = device or ("cuda" if torch.cuda.is_available() else "cpu")
+    if seed is not None:
+        set_seed(seed)
 
     if grad_clip is not None and grad_clip < 0:
         raise ValueError("grad_clip must be non-negative")

--- a/crosslearner/utils.py
+++ b/crosslearner/utils.py
@@ -1,0 +1,18 @@
+import os
+import random
+
+import numpy as np
+import torch
+
+
+def set_seed(seed: int, *, deterministic: bool = False) -> None:
+    """Set random seed for Python, NumPy and PyTorch."""
+    random.seed(seed)
+    np.random.seed(seed)
+    torch.manual_seed(seed)
+    torch.cuda.manual_seed_all(seed)
+    os.environ["PYTHONHASHSEED"] = str(seed)
+    if deterministic:
+        torch.use_deterministic_algorithms(True)
+        torch.backends.cudnn.deterministic = True
+        torch.backends.cudnn.benchmark = False

--- a/docs/usage_examples.rst
+++ b/docs/usage_examples.rst
@@ -32,8 +32,10 @@ model on the toy dataset and computes the final PEHE:
    from crosslearner.datasets.toy import get_toy_dataloader
    from crosslearner.training.train_acx import train_acx
    from crosslearner.evaluation import evaluate
+   from crosslearner import set_seed
    import torch
 
+   set_seed(0)
    loader, (mu0, mu1) = get_toy_dataloader()
    X = torch.cat([b[0] for b in loader])
 

--- a/tests/test_training.py
+++ b/tests/test_training.py
@@ -1,4 +1,5 @@
 import torch
+from crosslearner.utils import set_seed
 from crosslearner import __main__ as cli
 from crosslearner.benchmarks import run_benchmarks
 from crosslearner.datasets.toy import get_toy_dataloader
@@ -11,7 +12,7 @@ from torch.utils.data import DataLoader, TensorDataset
 
 
 def test_train_acx_short():
-    torch.manual_seed(0)
+    set_seed(0)
     loader, (mu0, mu1) = get_toy_dataloader(batch_size=16, n=64, p=4)
     model = train_acx(loader, p=4, device="cpu", epochs=2)
     X = torch.cat([b[0] for b in loader])
@@ -30,7 +31,7 @@ def test_tensorboard_logging(tmp_path):
 
 
 def test_weight_clipping():
-    torch.manual_seed(0)
+    set_seed(0)
     loader, _ = get_toy_dataloader(batch_size=16, n=64, p=4)
     model = train_acx(loader, p=4, device="cpu", epochs=1, weight_clip=0.01)
     for p in model.disc.parameters():
@@ -38,7 +39,7 @@ def test_weight_clipping():
 
 
 def test_early_stopping():
-    torch.manual_seed(0)
+    set_seed(0)
     loader, (mu0, mu1) = get_toy_dataloader(batch_size=16, n=64, p=4)
     X = torch.cat([b[0] for b in loader])
     val_data = (X, mu0, mu1)
@@ -55,7 +56,7 @@ def test_early_stopping():
 
 
 def test_risk_early_stopping():
-    torch.manual_seed(0)
+    set_seed(0)
     loader, _ = get_toy_dataloader(batch_size=16, n=64, p=4)
     X = torch.cat([b[0] for b in loader])
     T_all = torch.cat([b[1] for b in loader])
@@ -108,7 +109,7 @@ def test_run_benchmarks_all(monkeypatch):
 
 
 def test_train_acx_options():
-    torch.manual_seed(0)
+    set_seed(0)
     loader, (mu0, mu1) = get_toy_dataloader(batch_size=4, n=16, p=4)
     X = torch.cat([b[0] for b in loader])
     val_data = (X, mu0, mu1)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,8 +1,11 @@
 import pytest
 import torch
 import torch.nn as nn
+import numpy as np
+import random
 
 from crosslearner.models.acx import MLP, _get_activation
+from crosslearner.utils import set_seed
 
 
 def test_get_activation_invalid_name():
@@ -35,3 +38,14 @@ def test_mlp_forward_matches_sequential_without_residual():
     y_seq = mlp.net(x)
     y = mlp(x)
     assert torch.allclose(y, y_seq)
+
+
+def test_set_seed_reproducibility():
+    set_seed(123)
+    r1 = random.random()
+    n1 = np.random.rand(1)
+    t1 = torch.rand(1)
+    set_seed(123)
+    assert random.random() == r1
+    assert np.allclose(np.random.rand(1), n1)
+    assert torch.allclose(torch.rand(1), t1)

--- a/train.py
+++ b/train.py
@@ -2,6 +2,7 @@
 
 import torch
 
+from crosslearner.utils import set_seed
 from crosslearner.datasets.toy import get_toy_dataloader
 from crosslearner.training.train_acx import train_acx
 from crosslearner.evaluation.evaluate import evaluate
@@ -10,6 +11,7 @@ from crosslearner.evaluation.evaluate import evaluate
 def main():
     """Train a toy model and print the PEHE."""
 
+    set_seed(0)
     loader, (mu0, mu1) = get_toy_dataloader()
     device = "cuda" if torch.cuda.is_available() else "cpu"
     model = train_acx(loader, p=10, device=device)


### PR DESCRIPTION
## Summary
- introduce `set_seed` utility for reproducibility
- export `set_seed` from package API
- seed training loops, benchmarks and CLIs
- add documentation example for setting seeds
- add regression test for `set_seed`

## Testing
- `ruff check .`
- `black --check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68509f2fb1cc8324b7ad1fd17534404b