### PR TITLE
Refactor training API with config dataclasses

### DIFF
--- a/crosslearner/training/__init__.py
+++ b/crosslearner/training/__init__.py
@@ -1,1 +1,6 @@
 """Training helpers."""
+
+from .config import ModelConfig, TrainingConfig
+from .trainer import ACXTrainer
+
+__all__ = ["ModelConfig", "TrainingConfig", "ACXTrainer"]

--- a/crosslearner/training/config.py
+++ b/crosslearner/training/config.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Callable, Iterable, Optional, Tuple, Type
+
+import torch
+import torch.nn as nn
+
+
+@dataclass
+class ModelConfig:
+    """Configuration for the :class:`ACX` architecture."""
+
+    p: int
+    rep_dim: int = 64
+    phi_layers: Iterable[int] | None = (128,)
+    head_layers: Iterable[int] | None = (64,)
+    disc_layers: Iterable[int] | None = (64,)
+    activation: str | Callable[[], nn.Module] = "relu"
+    phi_dropout: float = 0.0
+    head_dropout: float = 0.0
+    disc_dropout: float = 0.0
+    residual: bool = False
+
+
+@dataclass
+class TrainingConfig:
+    """Hyperparameters controlling the training process."""
+
+    epochs: int = 30
+    alpha_out: float = 1.0
+    beta_cons: float = 10.0
+    gamma_adv: float = 1.0
+    lr_g: float = 1e-3
+    lr_d: float = 1e-3
+    optimizer: str | Type[torch.optim.Optimizer] = "adam"
+    opt_g_kwargs: dict = field(default_factory=dict)
+    opt_d_kwargs: dict = field(default_factory=dict)
+    lr_scheduler: str | Type[torch.optim.lr_scheduler._LRScheduler] | None = None
+    sched_g_kwargs: dict = field(default_factory=dict)
+    sched_d_kwargs: dict = field(default_factory=dict)
+    grad_clip: float = 2.0
+    warm_start: int = 0
+    use_wgan_gp: bool = False
+    spectral_norm: bool = False
+    feature_matching: bool = False
+    label_smoothing: bool = False
+    instance_noise: bool = False
+    gradient_reversal: bool = False
+    ttur: bool = False
+    lambda_gp: float = 10.0
+    eta_fm: float = 5.0
+    grl_weight: float = 1.0
+    tensorboard_logdir: Optional[str] = None
+    weight_clip: Optional[float] = None
+    val_data: Optional[Tuple[torch.Tensor, torch.Tensor, torch.Tensor]] = None
+    risk_data: Optional[Tuple[torch.Tensor, torch.Tensor, torch.Tensor]] = None
+    risk_folds: int = 5
+    nuisance_propensity_epochs: int = 500
+    nuisance_outcome_epochs: int = 3
+    nuisance_early_stop: int = 10
+    patience: int = 0
+    verbose: bool = True
+    return_history: bool = False

--- a/crosslearner/training/trainer.py
+++ b/crosslearner/training/trainer.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+from typing import Optional, Tuple
+
+import torch
+import torch.nn as nn
+from torch.utils.data import DataLoader
+
+from .config import ModelConfig, TrainingConfig
+from .history import History
+from ..models.acx import ACX, _get_activation
+from ..utils import set_seed
+
+
+class ACXTrainer:
+    """Trainer class encapsulating the ACX training loop."""
+
+    def __init__(
+        self,
+        model_cfg: ModelConfig,
+        train_cfg: TrainingConfig,
+        *,
+        device: Optional[str] = None,
+        seed: Optional[int] = None,
+    ) -> None:
+        self.model_cfg = model_cfg
+        self.train_cfg = train_cfg
+        self.device = device or ("cuda" if torch.cuda.is_available() else "cpu")
+        if seed is not None:
+            set_seed(seed)
+        act_fn = _get_activation(model_cfg.activation)
+        self.model = ACX(
+            model_cfg.p,
+            rep_dim=model_cfg.rep_dim,
+            phi_layers=model_cfg.phi_layers,
+            head_layers=model_cfg.head_layers,
+            disc_layers=model_cfg.disc_layers,
+            activation=act_fn,
+            phi_dropout=model_cfg.phi_dropout,
+            head_dropout=model_cfg.head_dropout,
+            disc_dropout=model_cfg.disc_dropout,
+            residual=model_cfg.residual,
+        ).to(self.device)
+        if train_cfg.spectral_norm:
+            for m in self.model.modules():
+                if isinstance(m, nn.Linear):
+                    nn.utils.spectral_norm(m)
+
+    def train(self, loader: DataLoader) -> ACX | Tuple[ACX, History]:
+        from .train_acx import train_acx
+
+        args = dict(vars(self.model_cfg))
+        args.update(vars(self.train_cfg))
+        args.update({"device": self.device})
+        return train_acx(loader, **args)


### PR DESCRIPTION
## Summary
- introduce `ModelConfig` and `TrainingConfig` dataclasses
- add `ACXTrainer` wrapper class
- update `train_acx` to accept optional configs

## Testing
- `ruff check .`
- `black --check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6850b2657ccc832491ce5631647b27e1