### PR TITLE
Refactor train_acx API

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ import optuna
 import torch
 from crosslearner.datasets.toy import get_toy_dataloader
 from crosslearner.training.train_acx import train_acx
+from crosslearner.training.config import ModelConfig, TrainingConfig
 from crosslearner.evaluation.evaluate import evaluate
 
 loader, (mu0, mu1) = get_toy_dataloader()
@@ -82,20 +83,17 @@ mu0_all = mu0
 mu1_all = mu1
 
 def objective(trial):
-    return evaluate(
-        train_acx(
-            loader,
-            p=10,
-            rep_dim=trial.suggest_int("rep_dim", 32, 128),
-            lr_g=trial.suggest_loguniform("lr_g", 1e-4, 1e-2),
-            lr_d=trial.suggest_loguniform("lr_d", 1e-4, 1e-2),
-            beta_cons=trial.suggest_float("beta_cons", 1.0, 20.0),
-            epochs=30,
-        ),
-        X,
-        mu0_all,
-        mu1_all,
+    model_cfg = ModelConfig(
+        p=10,
+        rep_dim=trial.suggest_int("rep_dim", 32, 128),
     )
+    train_cfg = TrainingConfig(
+        lr_g=trial.suggest_loguniform("lr_g", 1e-4, 1e-2),
+        lr_d=trial.suggest_loguniform("lr_d", 1e-4, 1e-2),
+        beta_cons=trial.suggest_float("beta_cons", 1.0, 20.0),
+        epochs=30,
+    )
+    return evaluate(train_acx(loader, model_cfg, train_cfg), X, mu0_all, mu1_all)
 
 study = optuna.create_study(direction="minimize")
 study.optimize(objective, n_trials=50)

--- a/crosslearner/__main__.py
+++ b/crosslearner/__main__.py
@@ -6,6 +6,7 @@ from crosslearner.utils import set_seed
 
 from crosslearner.datasets.toy import get_toy_dataloader
 from crosslearner.training.train_acx import train_acx
+from crosslearner.training.config import ModelConfig, TrainingConfig
 from crosslearner.evaluation.evaluate import evaluate
 
 
@@ -14,7 +15,9 @@ def main() -> None:
     set_seed(0)
     loader, (mu0, mu1) = get_toy_dataloader()
     device = "cuda" if torch.cuda.is_available() else "cpu"
-    model = train_acx(loader, p=10, device=device)
+    model_cfg = ModelConfig(p=10)
+    train_cfg = TrainingConfig()
+    model = train_acx(loader, model_cfg, train_cfg, device=device)
     X = torch.cat([b[0] for b in loader]).to(device)
     mu0_all = mu0.to(device)
     mu1_all = mu1.to(device)

--- a/crosslearner/benchmarks/run_benchmarks.py
+++ b/crosslearner/benchmarks/run_benchmarks.py
@@ -18,6 +18,7 @@ from crosslearner.datasets.twins import get_twins_dataloader
 from crosslearner.datasets.lalonde import get_lalonde_dataloader
 from crosslearner.datasets.synthetic import get_confounding_dataloader
 from crosslearner.training.train_acx import train_acx
+from crosslearner.training.config import ModelConfig, TrainingConfig
 from crosslearner.evaluation.evaluate import evaluate
 from crosslearner.evaluation.metrics import (
     policy_risk,
@@ -131,7 +132,9 @@ def run(dataset: str, replicates: int = 3, epochs: int = 30) -> List[Dict[str, f
             return [v for _, v in summary]
         else:
             raise ValueError(f"Unknown dataset {dataset}")
-        model = train_acx(loader, p=p, epochs=epochs, seed=seed)
+        model_cfg = ModelConfig(p=p)
+        train_cfg = TrainingConfig(epochs=epochs)
+        model = train_acx(loader, model_cfg, train_cfg, seed=seed)
         X = torch.cat([b[0] for b in loader])
         T_all = torch.cat([b[1] for b in loader])
         mu0_all = mu0

--- a/crosslearner/training/trainer.py
+++ b/crosslearner/training/trainer.py
@@ -49,7 +49,9 @@ class ACXTrainer:
     def train(self, loader: DataLoader) -> ACX | Tuple[ACX, History]:
         from .train_acx import train_acx
 
-        args = dict(vars(self.model_cfg))
-        args.update(vars(self.train_cfg))
-        args.update({"device": self.device})
-        return train_acx(loader, **args)
+        return train_acx(
+            loader,
+            self.model_cfg,
+            self.train_cfg,
+            device=self.device,
+        )

--- a/docs/hyperparameter_sweeps.rst
+++ b/docs/hyperparameter_sweeps.rst
@@ -14,6 +14,7 @@ The snippet below sweeps a few hyperparameters and minimises the validation
    import torch
    from crosslearner.datasets.toy import get_toy_dataloader
    from crosslearner.training.train_acx import train_acx
+   from crosslearner.training.config import ModelConfig, TrainingConfig
    from crosslearner.evaluation import evaluate
 
    loader, (mu0, mu1) = get_toy_dataloader()
@@ -22,21 +23,17 @@ The snippet below sweeps a few hyperparameters and minimises the validation
    mu1_all = mu1
 
    def objective(trial):
-       rep_dim = trial.suggest_int("rep_dim", 32, 128)
-       lr_g = trial.suggest_loguniform("lr_g", 1e-4, 1e-2)
-       lr_d = trial.suggest_loguniform("lr_d", 1e-4, 1e-2)
-       beta_cons = trial.suggest_float("beta_cons", 1.0, 20.0)
-
-       model = train_acx(
-           loader,
+       model_cfg = ModelConfig(
            p=10,
-           rep_dim=rep_dim,
-           lr_g=lr_g,
-           lr_d=lr_d,
-           beta_cons=beta_cons,
-           epochs=30,
-           device="cpu",
+           rep_dim=trial.suggest_int("rep_dim", 32, 128),
        )
+       train_cfg = TrainingConfig(
+           lr_g=trial.suggest_loguniform("lr_g", 1e-4, 1e-2),
+           lr_d=trial.suggest_loguniform("lr_d", 1e-4, 1e-2),
+           beta_cons=trial.suggest_float("beta_cons", 1.0, 20.0),
+           epochs=30,
+       )
+       model = train_acx(loader, model_cfg, train_cfg)
        return evaluate(model, X, mu0_all, mu1_all)
 
    study = optuna.create_study(direction="minimize")

--- a/docs/usage_examples.rst
+++ b/docs/usage_examples.rst
@@ -31,6 +31,7 @@ model on the toy dataset and computes the final PEHE:
 
    from crosslearner.datasets.toy import get_toy_dataloader
    from crosslearner.training.train_acx import train_acx
+   from crosslearner.training.config import ModelConfig, TrainingConfig
    from crosslearner.evaluation import evaluate
    from crosslearner import set_seed
    import torch
@@ -39,7 +40,9 @@ model on the toy dataset and computes the final PEHE:
    loader, (mu0, mu1) = get_toy_dataloader()
    X = torch.cat([b[0] for b in loader])
 
-   model = train_acx(loader, p=10, epochs=30)
+   model_cfg = ModelConfig(p=10)
+   train_cfg = TrainingConfig(epochs=30)
+   model = train_acx(loader, model_cfg, train_cfg)
    pehe = evaluate(model, X, mu0, mu1)
    print("sqrt(PEHE)", pehe)
 

--- a/tests/test_experiment_manager.py
+++ b/tests/test_experiment_manager.py
@@ -1,19 +1,22 @@
 import optuna
 from crosslearner.datasets.toy import get_toy_dataloader
 from crosslearner.experiments import ExperimentManager, cross_validate_acx
+from crosslearner.training.config import ModelConfig, TrainingConfig
 
 
 def test_cross_validate(tmp_path):
     loader, (mu0, mu1) = get_toy_dataloader(batch_size=4, n=16, p=3)
+    model_cfg = ModelConfig(p=3)
+    train_cfg = TrainingConfig(epochs=1)
     metric = cross_validate_acx(
         loader,
         mu0,
         mu1,
-        p=3,
+        model_cfg,
+        train_cfg,
         folds=2,
         device="cpu",
         log_dir=str(tmp_path),
-        epochs=1,
     )
     assert metric >= 0.0
     assert (tmp_path / "fold_0").exists()

--- a/tests/test_training.py
+++ b/tests/test_training.py
@@ -6,6 +6,7 @@ from crosslearner.datasets.toy import get_toy_dataloader
 from crosslearner.evaluation.evaluate import evaluate
 from crosslearner.models.acx import ACX
 from crosslearner.training.train_acx import train_acx
+from crosslearner.training.config import ModelConfig, TrainingConfig
 import torch.nn as nn
 import pytest
 from torch.utils.data import DataLoader, TensorDataset
@@ -14,7 +15,9 @@ from torch.utils.data import DataLoader, TensorDataset
 def test_train_acx_short():
     set_seed(0)
     loader, (mu0, mu1) = get_toy_dataloader(batch_size=16, n=64, p=4)
-    model = train_acx(loader, p=4, device="cpu", epochs=2)
+    model_cfg = ModelConfig(p=4)
+    train_cfg = TrainingConfig(epochs=2)
+    model = train_acx(loader, model_cfg, train_cfg, device="cpu")
     X = torch.cat([b[0] for b in loader])
     mu0_all = mu0
     mu1_all = mu1
@@ -26,14 +29,18 @@ def test_train_acx_short():
 def test_tensorboard_logging(tmp_path):
     loader, _ = get_toy_dataloader(batch_size=16, n=32, p=4)
     logdir = tmp_path / "tb"
-    train_acx(loader, p=4, device="cpu", epochs=1, tensorboard_logdir=str(logdir))
+    model_cfg = ModelConfig(p=4)
+    train_cfg = TrainingConfig(epochs=1, tensorboard_logdir=str(logdir))
+    train_acx(loader, model_cfg, train_cfg, device="cpu")
     assert any(logdir.iterdir())
 
 
 def test_weight_clipping():
     set_seed(0)
     loader, _ = get_toy_dataloader(batch_size=16, n=64, p=4)
-    model = train_acx(loader, p=4, device="cpu", epochs=1, weight_clip=0.01)
+    model_cfg = ModelConfig(p=4)
+    train_cfg = TrainingConfig(epochs=1, weight_clip=0.01)
+    model = train_acx(loader, model_cfg, train_cfg, device="cpu")
     for p in model.disc.parameters():
         assert p.data.abs().max() <= 0.011
 
@@ -43,15 +50,14 @@ def test_early_stopping():
     loader, (mu0, mu1) = get_toy_dataloader(batch_size=16, n=64, p=4)
     X = torch.cat([b[0] for b in loader])
     val_data = (X, mu0, mu1)
-    _, history = train_acx(
-        loader,
-        p=4,
-        device="cpu",
+    model_cfg = ModelConfig(p=4)
+    train_cfg = TrainingConfig(
         epochs=5,
         val_data=val_data,
         patience=1,
         return_history=True,
     )
+    _, history = train_acx(loader, model_cfg, train_cfg, device="cpu")
     assert len(history) <= 5
 
 
@@ -61,10 +67,8 @@ def test_risk_early_stopping():
     X = torch.cat([b[0] for b in loader])
     T_all = torch.cat([b[1] for b in loader])
     Y_all = torch.cat([b[2] for b in loader])
-    _, history = train_acx(
-        loader,
-        p=4,
-        device="cpu",
+    model_cfg = ModelConfig(p=4)
+    train_cfg = TrainingConfig(
         epochs=5,
         risk_data=(X, T_all, Y_all),
         risk_folds=2,
@@ -72,6 +76,7 @@ def test_risk_early_stopping():
         return_history=True,
         verbose=False,
     )
+    _, history = train_acx(loader, model_cfg, train_cfg, device="cpu")
     assert len(history) <= 5
 
 
@@ -113,10 +118,8 @@ def test_train_acx_options():
     loader, (mu0, mu1) = get_toy_dataloader(batch_size=4, n=16, p=4)
     X = torch.cat([b[0] for b in loader])
     val_data = (X, mu0, mu1)
-    train_acx(
-        loader,
-        p=4,
-        device="cpu",
+    model_cfg = ModelConfig(p=4)
+    train_cfg = TrainingConfig(
         epochs=2,
         warm_start=1,
         use_wgan_gp=True,
@@ -134,37 +137,35 @@ def test_train_acx_options():
         patience=1,
         verbose=False,
     )
+    train_acx(loader, model_cfg, train_cfg, device="cpu")
 
 
 def test_train_acx_custom_architecture():
     loader, _ = get_toy_dataloader(batch_size=8, n=32, p=3)
-    model = train_acx(
-        loader,
+    model_cfg = ModelConfig(
         p=3,
-        device="cpu",
-        epochs=1,
         rep_dim=16,
         phi_layers=[8],
         head_layers=[4],
         disc_layers=[4],
         activation="elu",
-        verbose=False,
     )
+    train_cfg = TrainingConfig(epochs=1, verbose=False)
+    model = train_acx(loader, model_cfg, train_cfg, device="cpu")
     assert isinstance(model, ACX)
 
 
 def test_train_acx_custom_optimizer():
     loader, _ = get_toy_dataloader(batch_size=8, n=32, p=3)
-    model = train_acx(
-        loader,
-        p=3,
-        device="cpu",
+    model_cfg = ModelConfig(p=3)
+    train_cfg = TrainingConfig(
         epochs=1,
         optimizer="sgd",
         opt_g_kwargs={"momentum": 0.0},
         opt_d_kwargs={"momentum": 0.0},
         verbose=False,
     )
+    model = train_acx(loader, model_cfg, train_cfg, device="cpu")
     assert isinstance(model, ACX)
 
 
@@ -182,44 +183,29 @@ def test_train_acx_custom_scheduler(monkeypatch):
 
     monkeypatch.setattr(torch.optim.lr_scheduler, "StepLR", DummyScheduler)
 
-    train_acx(
-        loader,
-        p=3,
-        device="cpu",
-        epochs=1,
-        lr_scheduler="step",
-        verbose=False,
-    )
+    model_cfg = ModelConfig(p=3)
+    train_cfg = TrainingConfig(epochs=1, lr_scheduler="step", verbose=False)
+    train_acx(loader, model_cfg, train_cfg, device="cpu")
 
     assert steps["count"] == 2
 
 
 def test_warm_start_logs_losses():
     loader, _ = get_toy_dataloader(batch_size=8, n=32, p=4)
-    _, history = train_acx(
-        loader,
-        p=4,
-        device="cpu",
-        epochs=2,
-        warm_start=1,
-        return_history=True,
-        verbose=False,
+    model_cfg = ModelConfig(p=4)
+    train_cfg = TrainingConfig(
+        epochs=2, warm_start=1, return_history=True, verbose=False
     )
+    _, history = train_acx(loader, model_cfg, train_cfg, device="cpu")
     assert history[0].loss_y > 0
     assert history[0].loss_g > 0
 
 
 def test_warm_start_grad_clip():
     loader, _ = get_toy_dataloader(batch_size=8, n=32, p=4)
-    model = train_acx(
-        loader,
-        p=4,
-        device="cpu",
-        epochs=2,
-        warm_start=1,
-        grad_clip=1.0,
-        verbose=False,
-    )
+    model_cfg = ModelConfig(p=4)
+    train_cfg = TrainingConfig(epochs=2, warm_start=1, grad_clip=1.0, verbose=False)
+    model = train_acx(loader, model_cfg, train_cfg, device="cpu")
     assert isinstance(model, ACX)
 
 
@@ -230,7 +216,9 @@ def test_train_acx_1d_targets():
     mu1 = mu0 + torch.randn(16)
     Y = torch.where(T.bool(), mu1, mu0) + 0.1 * torch.randn(16)
     loader = DataLoader(TensorDataset(X, T, Y), batch_size=8)
-    model = train_acx(loader, p=4, device="cpu", epochs=1, verbose=False)
+    model_cfg = ModelConfig(p=4)
+    train_cfg = TrainingConfig(epochs=1, verbose=False)
+    model = train_acx(loader, model_cfg, train_cfg, device="cpu")
     assert isinstance(model, ACX)
 
 
@@ -248,7 +236,9 @@ def test_instance_noise_keeps_targets(monkeypatch):
     monkeypatch.setattr(torch.nn, "MSELoss", lambda: RecMSE())
     monkeypatch.setattr(torch, "randn_like", lambda t: torch.ones_like(t))
 
-    train_acx(loader, p=4, device="cpu", epochs=1, instance_noise=True, verbose=False)
+    model_cfg = ModelConfig(p=4)
+    train_cfg = TrainingConfig(epochs=1, instance_noise=True, verbose=False)
+    train_acx(loader, model_cfg, train_cfg, device="cpu")
 
     assert torch.allclose(targets[0], loader.dataset.tensors[2][:4])
 
@@ -256,61 +246,64 @@ def test_instance_noise_keeps_targets(monkeypatch):
 def test_train_acx_feature_mismatch():
     loader, _ = get_toy_dataloader(batch_size=4, n=8, p=4)
     with pytest.raises(ValueError):
-        train_acx(loader, p=3, device="cpu", epochs=1, verbose=False)
+        model_cfg = ModelConfig(p=3)
+        train_cfg = TrainingConfig(epochs=1, verbose=False)
+        train_acx(loader, model_cfg, train_cfg, device="cpu")
 
 
 def test_train_acx_invalid_activation():
     loader, _ = get_toy_dataloader(batch_size=4, n=8, p=4)
     with pytest.raises(ValueError):
-        train_acx(loader, p=4, device="cpu", epochs=1, activation="bad", verbose=False)
+        model_cfg = ModelConfig(p=4, activation="bad")
+        train_cfg = TrainingConfig(epochs=1, verbose=False)
+        train_acx(loader, model_cfg, train_cfg, device="cpu")
 
 
 def test_train_acx_activation_instance():
     loader, _ = get_toy_dataloader(batch_size=4, n=8, p=4)
     with pytest.raises(TypeError):
-        train_acx(
-            loader, p=4, device="cpu", epochs=1, activation=nn.ReLU(), verbose=False
-        )
+        model_cfg = ModelConfig(p=4, activation=nn.ReLU())
+        train_cfg = TrainingConfig(epochs=1, verbose=False)
+        train_acx(loader, model_cfg, train_cfg, device="cpu")
 
 
 def test_train_acx_invalid_optimizer():
     loader, _ = get_toy_dataloader(batch_size=4, n=8, p=4)
     with pytest.raises(ValueError):
-        train_acx(loader, p=4, device="cpu", epochs=1, optimizer="bad", verbose=False)
+        model_cfg = ModelConfig(p=4)
+        train_cfg = TrainingConfig(epochs=1, optimizer="bad", verbose=False)
+        train_acx(loader, model_cfg, train_cfg, device="cpu")
 
 
 def test_train_acx_invalid_scheduler():
     loader, _ = get_toy_dataloader(batch_size=4, n=8, p=4)
     with pytest.raises(ValueError):
-        train_acx(
-            loader, p=4, device="cpu", epochs=1, lr_scheduler="bad", verbose=False
-        )
+        model_cfg = ModelConfig(p=4)
+        train_cfg = TrainingConfig(epochs=1, lr_scheduler="bad", verbose=False)
+        train_acx(loader, model_cfg, train_cfg, device="cpu")
 
 
 def test_train_acx_negative_grad_clip():
     loader, _ = get_toy_dataloader(batch_size=4, n=8, p=4)
     with pytest.raises(ValueError):
-        train_acx(loader, p=4, device="cpu", epochs=1, grad_clip=-1, verbose=False)
+        model_cfg = ModelConfig(p=4)
+        train_cfg = TrainingConfig(epochs=1, grad_clip=-1, verbose=False)
+        train_acx(loader, model_cfg, train_cfg, device="cpu")
 
 
 def test_train_acx_negative_weight_clip():
     loader, _ = get_toy_dataloader(batch_size=4, n=8, p=4)
     with pytest.raises(ValueError):
-        train_acx(loader, p=4, device="cpu", epochs=1, weight_clip=-0.1, verbose=False)
+        model_cfg = ModelConfig(p=4)
+        train_cfg = TrainingConfig(epochs=1, weight_clip=-0.1, verbose=False)
+        train_acx(loader, model_cfg, train_cfg, device="cpu")
 
 
 def test_train_acx_dropout_options():
     loader, _ = get_toy_dataloader(batch_size=4, n=8, p=4)
-    model = train_acx(
-        loader,
-        p=4,
-        device="cpu",
-        epochs=1,
-        phi_dropout=0.1,
-        head_dropout=0.1,
-        disc_dropout=0.1,
-        verbose=False,
-    )
+    model_cfg = ModelConfig(p=4, phi_dropout=0.1, head_dropout=0.1, disc_dropout=0.1)
+    train_cfg = TrainingConfig(epochs=1, verbose=False)
+    model = train_acx(loader, model_cfg, train_cfg, device="cpu")
     assert any(isinstance(m, nn.Dropout) for m in model.phi.net.modules())
     assert any(isinstance(m, nn.Dropout) for m in model.mu0.net.modules())
     assert any(isinstance(m, nn.Dropout) for m in model.disc.net.modules())


### PR DESCRIPTION
## Summary
- refactor `train_acx` to accept `ModelConfig` and `TrainingConfig`
- update trainer and experiment utilities for new API
- adjust CLI, benchmarks and docs
- rewrite tests for config-based API

## Testing
- `black --check .`
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6850b5be95d883248acccbe90d5a805c