### PR TITLE
Refactor train_acx API

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ import optuna
 import torch
 from crosslearner.datasets.toy import get_toy_dataloader
 from crosslearner.training.train_acx import train_acx
+from crosslearner.training.config import ModelConfig, TrainingConfig
 from crosslearner.evaluation.evaluate import evaluate
 
 loader, (mu0, mu1) = get_toy_dataloader()
@@ -82,20 +83,17 @@ mu0_all = mu0
 mu1_all = mu1
 
 def objective(trial):
-    return evaluate(
-        train_acx(
-            loader,
-            p=10,
-            rep_dim=trial.suggest_int("rep_dim", 32, 128),
-            lr_g=trial.suggest_loguniform("lr_g", 1e-4, 1e-2),
-            lr_d=trial.suggest_loguniform("lr_d", 1e-4, 1e-2),
-            beta_cons=trial.suggest_float("beta_cons", 1.0, 20.0),
-            epochs=30,
-        ),
-        X,
-        mu0_all,
-        mu1_all,
+    model_cfg = ModelConfig(
+        p=10,
+        rep_dim=trial.suggest_int("rep_dim", 32, 128),
     )
+    train_cfg = TrainingConfig(
+        lr_g=trial.suggest_loguniform("lr_g", 1e-4, 1e-2),
+        lr_d=trial.suggest_loguniform("lr_d", 1e-4, 1e-2),
+        beta_cons=trial.suggest_float("beta_cons", 1.0, 20.0),
+        epochs=30,
+    )
+    return evaluate(train_acx(loader, model_cfg, train_cfg), X, mu0_all, mu1_all)
 
 study = optuna.create_study(direction="minimize")
 study.optimize(objective, n_trials=50)

--- a/crosslearner/__main__.py
+++ b/crosslearner/__main__.py
@@ -6,6 +6,7 @@ from crosslearner.utils import set_seed
 
 from crosslearner.datasets.toy import get_toy_dataloader
 from crosslearner.training.train_acx import train_acx
+from crosslearner.training.config import ModelConfig, TrainingConfig
 from crosslearner.evaluation.evaluate import evaluate
 
 
@@ -14,7 +15,9 @@ def main() -> None:
     set_seed(0)
     loader, (mu0, mu1) = get_toy_dataloader()
     device = "cuda" if torch.cuda.is_available() else "cpu"
-    model = train_acx(loader, p=10, device=device)
+    model_cfg = ModelConfig(p=10)
+    train_cfg = TrainingConfig()
+    model = train_acx(loader, model_cfg, train_cfg, device=device)
     X = torch.cat([b[0] for b in loader]).to(device)
     mu0_all = mu0.to(device)
     mu1_all = mu1.to(device)

--- a/crosslearner/benchmarks/run_benchmarks.py
+++ b/crosslearner/benchmarks/run_benchmarks.py
@@ -18,6 +18,7 @@ from crosslearner.datasets.twins import get_twins_dataloader
 from crosslearner.datasets.lalonde import get_lalonde_dataloader
 from crosslearner.datasets.synthetic import get_confounding_dataloader
 from crosslearner.training.train_acx import train_acx
+from crosslearner.training.config import ModelConfig, TrainingConfig
 from crosslearner.evaluation.evaluate import evaluate
 from crosslearner.evaluation.metrics import (
     policy_risk,
@@ -131,7 +132,9 @@ def run(dataset: str, replicates: int = 3, epochs: int = 30) -> List[Dict[str, f
             return [v for _, v in summary]
         else:
             raise ValueError(f"Unknown dataset {dataset}")
-        model = train_acx(loader, p=p, epochs=epochs, seed=seed)
+        model_cfg = ModelConfig(p=p)
+        train_cfg = TrainingConfig(epochs=epochs)
+        model = train_acx(loader, model_cfg, train_cfg, seed=seed)
         X = torch.cat([b[0] for b in loader])
         T_all = torch.cat([b[1] for b in loader])
         mu0_all = mu0

--- a/crosslearner/training/train_acx.py
+++ b/crosslearner/training/train_acx.py
@@ -1,7 +1,7 @@
 import torch
 import torch.nn as nn
 from torch.utils.data import DataLoader
-from typing import Callable, Iterable, Optional, Tuple, Type
+from typing import Iterable, Optional
 from torch.utils.tensorboard import SummaryWriter
 from sklearn.model_selection import StratifiedKFold
 
@@ -208,179 +208,75 @@ def _orthogonal_risk(
 
 def train_acx(
     loader: DataLoader,
-    p: int,
+    model_cfg: ModelConfig,
+    train_cfg: TrainingConfig,
     *,
-    model_config: ModelConfig | None = None,
-    training_config: TrainingConfig | None = None,
-    rep_dim: int = 64,
-    phi_layers: Iterable[int] | None = (128,),
-    head_layers: Iterable[int] | None = (64,),
-    disc_layers: Iterable[int] | None = (64,),
-    activation: str | Callable[[], nn.Module] = "relu",
-    phi_dropout: float = 0.0,
-    head_dropout: float = 0.0,
-    disc_dropout: float = 0.0,
-    residual: bool = False,
     device: Optional[str] = None,
     seed: int | None = None,
-    epochs: int = 30,
-    alpha_out: float = 1.0,
-    beta_cons: float = 10.0,
-    gamma_adv: float = 1.0,
-    lr_g: float = 1e-3,
-    lr_d: float = 1e-3,
-    optimizer: str | Type[torch.optim.Optimizer] = "adam",
-    opt_g_kwargs: dict | None = None,
-    opt_d_kwargs: dict | None = None,
-    lr_scheduler: str | Type[torch.optim.lr_scheduler._LRScheduler] | None = None,
-    sched_g_kwargs: dict | None = None,
-    sched_d_kwargs: dict | None = None,
-    grad_clip: float = 2.0,
-    warm_start: int = 0,
-    use_wgan_gp: bool = False,
-    spectral_norm: bool = False,
-    feature_matching: bool = False,
-    label_smoothing: bool = False,
-    instance_noise: bool = False,
-    gradient_reversal: bool = False,
-    ttur: bool = False,
-    lambda_gp: float = 10.0,
-    eta_fm: float = 5.0,
-    grl_weight: float = 1.0,
-    tensorboard_logdir: Optional[str] = None,
-    weight_clip: Optional[float] = None,
-    val_data: Optional[Tuple[torch.Tensor, torch.Tensor, torch.Tensor]] = None,
-    risk_data: Optional[Tuple[torch.Tensor, torch.Tensor, torch.Tensor]] = None,
-    risk_folds: int = 5,
-    nuisance_propensity_epochs: int = 500,
-    nuisance_outcome_epochs: int = 3,
-    nuisance_early_stop: int = 10,
-    patience: int = 0,
-    verbose: bool = True,
-    return_history: bool = False,
 ) -> ACX | tuple[ACX, History]:
     """Train AC-X model with optional GAN tricks.
 
+    Parameters are read from ``model_cfg`` and ``train_cfg``. ``device`` and
+    ``seed`` override the defaults from the configuration.
+
     Args:
-        loader: PyTorch dataloader yielding ``(X, T, Y)`` batches.
-        p: Number of covariates.
-        model_config: Optional :class:`ModelConfig` with architecture
-            hyperparameters. When supplied, the corresponding keyword arguments
-            are ignored.
-        training_config: Optional :class:`TrainingConfig` holding optimisation
-            parameters. When given, the individual keyword arguments are
-            overridden.
-        rep_dim: Dimensionality of the shared representation ``phi``.
-        phi_layers: Hidden layers for the representation MLP.
-        head_layers: Hidden layers for the outcome and effect heads.
-        disc_layers: Hidden layers for the discriminator.
-        activation: Activation function used in all networks.
-        phi_dropout: Dropout probability for the representation MLP.
-        head_dropout: Dropout probability for the outcome and effect heads.
-        disc_dropout: Dropout probability for the discriminator.
-        residual: Enable residual connections in all MLPs.
-        device: Device string, defaults to CUDA if available.
+        loader: Dataloader yielding ``(X, T, Y)`` batches.
+        model_cfg: Architecture options for :class:`ACX`.
+        train_cfg: Hyperparameters controlling optimisation.
+        device: Optional device string, defaults to CUDA if available.
         seed: Optional random seed for reproducibility.
-        epochs: Number of training epochs.
-        alpha_out: Weight of the outcome loss.
-        beta_cons: Weight of the consistency term.
-        gamma_adv: Weight of the adversarial loss.
-        lr_g: Learning rate for generator parameters.
-        lr_d: Learning rate for the discriminator.
-        optimizer: Optimiser used for both generator and discriminator. Either
-            a string (``"adam"``, ``"sgd"``, ``"adamw"`` or ``"rmsprop"``) or an
-            optimiser class.
-        opt_g_kwargs: Optional dictionary with extra arguments for the generator
-            optimiser.
-        opt_d_kwargs: Optional dictionary with extra arguments for the
-            discriminator optimiser.
-        lr_scheduler: Optional learning rate scheduler used for both optimisers.
-            May be a string (``"step"``, ``"multistep"``, ``"exponential``",
-            ``"cosine"`` or ``"plateau"``) or a scheduler class.
-        sched_g_kwargs: Extra keyword arguments for the generator scheduler.
-        sched_d_kwargs: Extra keyword arguments for the discriminator scheduler.
-        grad_clip: Maximum gradient norm.
-        warm_start: Number of epochs to train without adversary.
-        use_wgan_gp: Use WGAN-GP loss for the discriminator.
-        spectral_norm: Apply spectral normalization to all linear layers.
-        feature_matching: Add feature matching loss.
-        label_smoothing: Use label smoothing for the adversary.
-        instance_noise: Inject Gaussian noise into real and fake samples.
-        gradient_reversal: Use gradient reversal instead of the adversary.
-        ttur: Enable the Two Time-Update Rule which freezes the discriminator
-            once its loss drops below a threshold, allowing the generator to
-            catch up.
-        lambda_gp: Coefficient of the gradient penalty term used in the
-            WGAN-GP objective. Only effective when ``use_wgan_gp`` is ``True``.
-        eta_fm: Weight of the feature matching term.
-        grl_weight: Scale of the gradient reversal layer.
-        tensorboard_logdir: Directory for TensorBoard logs.
-        weight_clip: Optional weight clipping for the discriminator.
-        val_data: Tuple ``(X, mu0, mu1)`` for validation PEHE.
-        risk_data: Optional tuple ``(X, T, Y)`` to early-stop on orthogonal risk
-            when counterfactuals are unavailable.
-        risk_folds: Number of cross-fitting folds for ``risk_data``.
-        nuisance_propensity_epochs: Training epochs for the propensity model.
-        nuisance_outcome_epochs: Training epochs for the outcome models.
-        nuisance_early_stop: Early-stopping patience for nuisance models.
-        patience: Early-stopping patience based on validation metric.
-        verbose: Print progress every 5 epochs.
-        return_history: If ``True`` also return training history.
 
     Returns:
         The trained ``ACX`` model. If ``return_history`` is ``True`` the
         function instead returns ``(model, history)`` where ``history`` is a
         list of :class:`EpochStats`.
     """
-    if model_config is not None:
-        if model_config.p != p:
-            raise ValueError("p does not match model_config.p")
-        rep_dim = model_config.rep_dim
-        phi_layers = model_config.phi_layers
-        head_layers = model_config.head_layers
-        disc_layers = model_config.disc_layers
-        activation = model_config.activation
-        phi_dropout = model_config.phi_dropout
-        head_dropout = model_config.head_dropout
-        disc_dropout = model_config.disc_dropout
-        residual = model_config.residual
+    p = model_cfg.p
+    rep_dim = model_cfg.rep_dim
+    phi_layers = model_cfg.phi_layers
+    head_layers = model_cfg.head_layers
+    disc_layers = model_cfg.disc_layers
+    activation = model_cfg.activation
+    phi_dropout = model_cfg.phi_dropout
+    head_dropout = model_cfg.head_dropout
+    disc_dropout = model_cfg.disc_dropout
+    residual = model_cfg.residual
 
-    if training_config is not None:
-        epochs = training_config.epochs
-        alpha_out = training_config.alpha_out
-        beta_cons = training_config.beta_cons
-        gamma_adv = training_config.gamma_adv
-        lr_g = training_config.lr_g
-        lr_d = training_config.lr_d
-        optimizer = training_config.optimizer
-        opt_g_kwargs = training_config.opt_g_kwargs
-        opt_d_kwargs = training_config.opt_d_kwargs
-        lr_scheduler = training_config.lr_scheduler
-        sched_g_kwargs = training_config.sched_g_kwargs
-        sched_d_kwargs = training_config.sched_d_kwargs
-        grad_clip = training_config.grad_clip
-        warm_start = training_config.warm_start
-        use_wgan_gp = training_config.use_wgan_gp
-        spectral_norm = training_config.spectral_norm
-        feature_matching = training_config.feature_matching
-        label_smoothing = training_config.label_smoothing
-        instance_noise = training_config.instance_noise
-        gradient_reversal = training_config.gradient_reversal
-        ttur = training_config.ttur
-        lambda_gp = training_config.lambda_gp
-        eta_fm = training_config.eta_fm
-        grl_weight = training_config.grl_weight
-        tensorboard_logdir = training_config.tensorboard_logdir
-        weight_clip = training_config.weight_clip
-        val_data = training_config.val_data
-        risk_data = training_config.risk_data
-        risk_folds = training_config.risk_folds
-        nuisance_propensity_epochs = training_config.nuisance_propensity_epochs
-        nuisance_outcome_epochs = training_config.nuisance_outcome_epochs
-        nuisance_early_stop = training_config.nuisance_early_stop
-        patience = training_config.patience
-        verbose = training_config.verbose
-        return_history = training_config.return_history
+    epochs = train_cfg.epochs
+    alpha_out = train_cfg.alpha_out
+    beta_cons = train_cfg.beta_cons
+    gamma_adv = train_cfg.gamma_adv
+    lr_g = train_cfg.lr_g
+    lr_d = train_cfg.lr_d
+    optimizer = train_cfg.optimizer
+    opt_g_kwargs = train_cfg.opt_g_kwargs
+    opt_d_kwargs = train_cfg.opt_d_kwargs
+    lr_scheduler = train_cfg.lr_scheduler
+    sched_g_kwargs = train_cfg.sched_g_kwargs
+    sched_d_kwargs = train_cfg.sched_d_kwargs
+    grad_clip = train_cfg.grad_clip
+    warm_start = train_cfg.warm_start
+    use_wgan_gp = train_cfg.use_wgan_gp
+    spectral_norm = train_cfg.spectral_norm
+    feature_matching = train_cfg.feature_matching
+    label_smoothing = train_cfg.label_smoothing
+    instance_noise = train_cfg.instance_noise
+    gradient_reversal = train_cfg.gradient_reversal
+    ttur = train_cfg.ttur
+    lambda_gp = train_cfg.lambda_gp
+    eta_fm = train_cfg.eta_fm
+    grl_weight = train_cfg.grl_weight
+    tensorboard_logdir = train_cfg.tensorboard_logdir
+    weight_clip = train_cfg.weight_clip
+    val_data = train_cfg.val_data
+    risk_data = train_cfg.risk_data
+    risk_folds = train_cfg.risk_folds
+    nuisance_propensity_epochs = train_cfg.nuisance_propensity_epochs
+    nuisance_outcome_epochs = train_cfg.nuisance_outcome_epochs
+    nuisance_early_stop = train_cfg.nuisance_early_stop
+    patience = train_cfg.patience
+    verbose = train_cfg.verbose
+    return_history = train_cfg.return_history
 
     device = device or ("cuda" if torch.cuda.is_available() else "cpu")
     if seed is not None:

--- a/crosslearner/training/trainer.py
+++ b/crosslearner/training/trainer.py
@@ -49,7 +49,9 @@ class ACXTrainer:
     def train(self, loader: DataLoader) -> ACX | Tuple[ACX, History]:
         from .train_acx import train_acx
 
-        args = dict(vars(self.model_cfg))
-        args.update(vars(self.train_cfg))
-        args.update({"device": self.device})
-        return train_acx(loader, **args)
+        return train_acx(
+            loader,
+            self.model_cfg,
+            self.train_cfg,
+            device=self.device,
+        )

--- a/docs/hyperparameter_sweeps.rst
+++ b/docs/hyperparameter_sweeps.rst
@@ -14,6 +14,7 @@ The snippet below sweeps a few hyperparameters and minimises the validation
    import torch
    from crosslearner.datasets.toy import get_toy_dataloader
    from crosslearner.training.train_acx import train_acx
+   from crosslearner.training.config import ModelConfig, TrainingConfig
    from crosslearner.evaluation import evaluate
 
    loader, (mu0, mu1) = get_toy_dataloader()
@@ -22,21 +23,17 @@ The snippet below sweeps a few hyperparameters and minimises the validation
    mu1_all = mu1
 
    def objective(trial):
-       rep_dim = trial.suggest_int("rep_dim", 32, 128)
-       lr_g = trial.suggest_loguniform("lr_g", 1e-4, 1e-2)
-       lr_d = trial.suggest_loguniform("lr_d", 1e-4, 1e-2)
-       beta_cons = trial.suggest_float("beta_cons", 1.0, 20.0)
-
-       model = train_acx(
-           loader,
+       model_cfg = ModelConfig(
            p=10,
-           rep_dim=rep_dim,
-           lr_g=lr_g,
-           lr_d=lr_d,
-           beta_cons=beta_cons,
-           epochs=30,
-           device="cpu",
+           rep_dim=trial.suggest_int("rep_dim", 32, 128),
        )
+       train_cfg = TrainingConfig(
+           lr_g=trial.suggest_loguniform("lr_g", 1e-4, 1e-2),
+           lr_d=trial.suggest_loguniform("lr_d", 1e-4, 1e-2),
+           beta_cons=trial.suggest_float("beta_cons", 1.0, 20.0),
+           epochs=30,
+       )
+       model = train_acx(loader, model_cfg, train_cfg)
        return evaluate(model, X, mu0_all, mu1_all)
 
    study = optuna.create_study(direction="minimize")

--- a/docs/usage_examples.rst
+++ b/docs/usage_examples.rst
@@ -31,6 +31,7 @@ model on the toy dataset and computes the final PEHE:
 
    from crosslearner.datasets.toy import get_toy_dataloader
    from crosslearner.training.train_acx import train_acx
+   from crosslearner.training.config import ModelConfig, TrainingConfig
    from crosslearner.evaluation import evaluate
    from crosslearner import set_seed
    import torch
@@ -39,7 +40,9 @@ model on the toy dataset and computes the final PEHE:
    loader, (mu0, mu1) = get_toy_dataloader()
    X = torch.cat([b[0] for b in loader])
 
-   model = train_acx(loader, p=10, epochs=30)
+   model_cfg = ModelConfig(p=10)
+   train_cfg = TrainingConfig(epochs=30)
+   model = train_acx(loader, model_cfg, train_cfg)
    pehe = evaluate(model, X, mu0, mu1)
    print("sqrt(PEHE)", pehe)
 

--- a/tests/test_experiment_manager.py
+++ b/tests/test_experiment_manager.py
@@ -1,19 +1,22 @@
 import optuna
 from crosslearner.datasets.toy import get_toy_dataloader
 from crosslearner.experiments import ExperimentManager, cross_validate_acx
+from crosslearner.training.config import ModelConfig, TrainingConfig
 
 
 def test_cross_validate(tmp_path):
     loader, (mu0, mu1) = get_toy_dataloader(batch_size=4, n=16, p=3)
+    model_cfg = ModelConfig(p=3)
+    train_cfg = TrainingConfig(epochs=1)
     metric = cross_validate_acx(
         loader,
         mu0,
         mu1,
-        p=3,
+        model_cfg,
+        train_cfg,
         folds=2,
         device="cpu",
         log_dir=str(tmp_path),
-        epochs=1,
     )
     assert metric >= 0.0
     assert (tmp_path / "fold_0").exists()

--- a/tests/test_training.py
+++ b/tests/test_training.py
@@ -6,6 +6,7 @@ from crosslearner.datasets.toy import get_toy_dataloader
 from crosslearner.evaluation.evaluate import evaluate
 from crosslearner.models.acx import ACX
 from crosslearner.training.train_acx import train_acx
+from crosslearner.training.config import ModelConfig, TrainingConfig
 import torch.nn as nn
 import pytest
 from torch.utils.data import DataLoader, TensorDataset
@@ -14,7 +15,9 @@ from torch.utils.data import DataLoader, TensorDataset
 def test_train_acx_short():
     set_seed(0)
     loader, (mu0, mu1) = get_toy_dataloader(batch_size=16, n=64, p=4)
-    model = train_acx(loader, p=4, device="cpu", epochs=2)
+    model_cfg = ModelConfig(p=4)
+    train_cfg = TrainingConfig(epochs=2)
+    model = train_acx(loader, model_cfg, train_cfg, device="cpu")
     X = torch.cat([b[0] for b in loader])
     mu0_all = mu0
     mu1_all = mu1
@@ -26,14 +29,18 @@ def test_train_acx_short():
 def test_tensorboard_logging(tmp_path):
     loader, _ = get_toy_dataloader(batch_size=16, n=32, p=4)
     logdir = tmp_path / "tb"
-    train_acx(loader, p=4, device="cpu", epochs=1, tensorboard_logdir=str(logdir))
+    model_cfg = ModelConfig(p=4)
+    train_cfg = TrainingConfig(epochs=1, tensorboard_logdir=str(logdir))
+    train_acx(loader, model_cfg, train_cfg, device="cpu")
     assert any(logdir.iterdir())
 
 
 def test_weight_clipping():
     set_seed(0)
     loader, _ = get_toy_dataloader(batch_size=16, n=64, p=4)
-    model = train_acx(loader, p=4, device="cpu", epochs=1, weight_clip=0.01)
+    model_cfg = ModelConfig(p=4)
+    train_cfg = TrainingConfig(epochs=1, weight_clip=0.01)
+    model = train_acx(loader, model_cfg, train_cfg, device="cpu")
     for p in model.disc.parameters():
         assert p.data.abs().max() <= 0.011
 
@@ -43,15 +50,14 @@ def test_early_stopping():
     loader, (mu0, mu1) = get_toy_dataloader(batch_size=16, n=64, p=4)
     X = torch.cat([b[0] for b in loader])
     val_data = (X, mu0, mu1)
-    _, history = train_acx(
-        loader,
-        p=4,
-        device="cpu",
+    model_cfg = ModelConfig(p=4)
+    train_cfg = TrainingConfig(
         epochs=5,
         val_data=val_data,
         patience=1,
         return_history=True,
     )
+    _, history = train_acx(loader, model_cfg, train_cfg, device="cpu")
     assert len(history) <= 5
 
 
@@ -61,10 +67,8 @@ def test_risk_early_stopping():
     X = torch.cat([b[0] for b in loader])
     T_all = torch.cat([b[1] for b in loader])
     Y_all = torch.cat([b[2] for b in loader])
-    _, history = train_acx(
-        loader,
-        p=4,
-        device="cpu",
+    model_cfg = ModelConfig(p=4)
+    train_cfg = TrainingConfig(
         epochs=5,
         risk_data=(X, T_all, Y_all),
         risk_folds=2,
@@ -72,6 +76,7 @@ def test_risk_early_stopping():
         return_history=True,
         verbose=False,
     )
+    _, history = train_acx(loader, model_cfg, train_cfg, device="cpu")
     assert len(history) <= 5
 
 
@@ -113,10 +118,8 @@ def test_train_acx_options():
     loader, (mu0, mu1) = get_toy_dataloader(batch_size=4, n=16, p=4)
     X = torch.cat([b[0] for b in loader])
     val_data = (X, mu0, mu1)
-    train_acx(
-        loader,
-        p=4,
-        device="cpu",
+    model_cfg = ModelConfig(p=4)
+    train_cfg = TrainingConfig(
         epochs=2,
         warm_start=1,
         use_wgan_gp=True,
@@ -134,37 +137,35 @@ def test_train_acx_options():
         patience=1,
         verbose=False,
     )
+    train_acx(loader, model_cfg, train_cfg, device="cpu")
 
 
 def test_train_acx_custom_architecture():
     loader, _ = get_toy_dataloader(batch_size=8, n=32, p=3)
-    model = train_acx(
-        loader,
+    model_cfg = ModelConfig(
         p=3,
-        device="cpu",
-        epochs=1,
         rep_dim=16,
         phi_layers=[8],
         head_layers=[4],
         disc_layers=[4],
         activation="elu",
-        verbose=False,
     )
+    train_cfg = TrainingConfig(epochs=1, verbose=False)
+    model = train_acx(loader, model_cfg, train_cfg, device="cpu")
     assert isinstance(model, ACX)
 
 
 def test_train_acx_custom_optimizer():
     loader, _ = get_toy_dataloader(batch_size=8, n=32, p=3)
-    model = train_acx(
-        loader,
-        p=3,
-        device="cpu",
+    model_cfg = ModelConfig(p=3)
+    train_cfg = TrainingConfig(
         epochs=1,
         optimizer="sgd",
         opt_g_kwargs={"momentum": 0.0},
         opt_d_kwargs={"momentum": 0.0},
         verbose=False,
     )
+    model = train_acx(loader, model_cfg, train_cfg, device="cpu")
     assert isinstance(model, ACX)
 
 
@@ -182,44 +183,29 @@ def test_train_acx_custom_scheduler(monkeypatch):
 
     monkeypatch.setattr(torch.optim.lr_scheduler, "StepLR", DummyScheduler)
 
-    train_acx(
-        loader,
-        p=3,
-        device="cpu",
-        epochs=1,
-        lr_scheduler="step",
-        verbose=False,
-    )
+    model_cfg = ModelConfig(p=3)
+    train_cfg = TrainingConfig(epochs=1, lr_scheduler="step", verbose=False)
+    train_acx(loader, model_cfg, train_cfg, device="cpu")
 
     assert steps["count"] == 2
 
 
 def test_warm_start_logs_losses():
     loader, _ = get_toy_dataloader(batch_size=8, n=32, p=4)
-    _, history = train_acx(
-        loader,
-        p=4,
-        device="cpu",
-        epochs=2,
-        warm_start=1,
-        return_history=True,
-        verbose=False,
+    model_cfg = ModelConfig(p=4)
+    train_cfg = TrainingConfig(
+        epochs=2, warm_start=1, return_history=True, verbose=False
     )
+    _, history = train_acx(loader, model_cfg, train_cfg, device="cpu")
     assert history[0].loss_y > 0
     assert history[0].loss_g > 0
 
 
 def test_warm_start_grad_clip():
     loader, _ = get_toy_dataloader(batch_size=8, n=32, p=4)
-    model = train_acx(
-        loader,
-        p=4,
-        device="cpu",
-        epochs=2,
-        warm_start=1,
-        grad_clip=1.0,
-        verbose=False,
-    )
+    model_cfg = ModelConfig(p=4)
+    train_cfg = TrainingConfig(epochs=2, warm_start=1, grad_clip=1.0, verbose=False)
+    model = train_acx(loader, model_cfg, train_cfg, device="cpu")
     assert isinstance(model, ACX)
 
 
@@ -230,7 +216,9 @@ def test_train_acx_1d_targets():
     mu1 = mu0 + torch.randn(16)
     Y = torch.where(T.bool(), mu1, mu0) + 0.1 * torch.randn(16)
     loader = DataLoader(TensorDataset(X, T, Y), batch_size=8)
-    model = train_acx(loader, p=4, device="cpu", epochs=1, verbose=False)
+    model_cfg = ModelConfig(p=4)
+    train_cfg = TrainingConfig(epochs=1, verbose=False)
+    model = train_acx(loader, model_cfg, train_cfg, device="cpu")
     assert isinstance(model, ACX)
 
 
@@ -248,7 +236,9 @@ def test_instance_noise_keeps_targets(monkeypatch):
     monkeypatch.setattr(torch.nn, "MSELoss", lambda: RecMSE())
     monkeypatch.setattr(torch, "randn_like", lambda t: torch.ones_like(t))
 
-    train_acx(loader, p=4, device="cpu", epochs=1, instance_noise=True, verbose=False)
+    model_cfg = ModelConfig(p=4)
+    train_cfg = TrainingConfig(epochs=1, instance_noise=True, verbose=False)
+    train_acx(loader, model_cfg, train_cfg, device="cpu")
 
     assert torch.allclose(targets[0], loader.dataset.tensors[2][:4])
 
@@ -256,61 +246,64 @@ def test_instance_noise_keeps_targets(monkeypatch):
 def test_train_acx_feature_mismatch():
     loader, _ = get_toy_dataloader(batch_size=4, n=8, p=4)
     with pytest.raises(ValueError):
-        train_acx(loader, p=3, device="cpu", epochs=1, verbose=False)
+        model_cfg = ModelConfig(p=3)
+        train_cfg = TrainingConfig(epochs=1, verbose=False)
+        train_acx(loader, model_cfg, train_cfg, device="cpu")
 
 
 def test_train_acx_invalid_activation():
     loader, _ = get_toy_dataloader(batch_size=4, n=8, p=4)
     with pytest.raises(ValueError):
-        train_acx(loader, p=4, device="cpu", epochs=1, activation="bad", verbose=False)
+        model_cfg = ModelConfig(p=4, activation="bad")
+        train_cfg = TrainingConfig(epochs=1, verbose=False)
+        train_acx(loader, model_cfg, train_cfg, device="cpu")
 
 
 def test_train_acx_activation_instance():
     loader, _ = get_toy_dataloader(batch_size=4, n=8, p=4)
     with pytest.raises(TypeError):
-        train_acx(
-            loader, p=4, device="cpu", epochs=1, activation=nn.ReLU(), verbose=False
-        )
+        model_cfg = ModelConfig(p=4, activation=nn.ReLU())
+        train_cfg = TrainingConfig(epochs=1, verbose=False)
+        train_acx(loader, model_cfg, train_cfg, device="cpu")
 
 
 def test_train_acx_invalid_optimizer():
     loader, _ = get_toy_dataloader(batch_size=4, n=8, p=4)
     with pytest.raises(ValueError):
-        train_acx(loader, p=4, device="cpu", epochs=1, optimizer="bad", verbose=False)
+        model_cfg = ModelConfig(p=4)
+        train_cfg = TrainingConfig(epochs=1, optimizer="bad", verbose=False)
+        train_acx(loader, model_cfg, train_cfg, device="cpu")
 
 
 def test_train_acx_invalid_scheduler():
     loader, _ = get_toy_dataloader(batch_size=4, n=8, p=4)
     with pytest.raises(ValueError):
-        train_acx(
-            loader, p=4, device="cpu", epochs=1, lr_scheduler="bad", verbose=False
-        )
+        model_cfg = ModelConfig(p=4)
+        train_cfg = TrainingConfig(epochs=1, lr_scheduler="bad", verbose=False)
+        train_acx(loader, model_cfg, train_cfg, device="cpu")
 
 
 def test_train_acx_negative_grad_clip():
     loader, _ = get_toy_dataloader(batch_size=4, n=8, p=4)
     with pytest.raises(ValueError):
-        train_acx(loader, p=4, device="cpu", epochs=1, grad_clip=-1, verbose=False)
+        model_cfg = ModelConfig(p=4)
+        train_cfg = TrainingConfig(epochs=1, grad_clip=-1, verbose=False)
+        train_acx(loader, model_cfg, train_cfg, device="cpu")
 
 
 def test_train_acx_negative_weight_clip():
     loader, _ = get_toy_dataloader(batch_size=4, n=8, p=4)
     with pytest.raises(ValueError):
-        train_acx(loader, p=4, device="cpu", epochs=1, weight_clip=-0.1, verbose=False)
+        model_cfg = ModelConfig(p=4)
+        train_cfg = TrainingConfig(epochs=1, weight_clip=-0.1, verbose=False)
+        train_acx(loader, model_cfg, train_cfg, device="cpu")
 
 
 def test_train_acx_dropout_options():
     loader, _ = get_toy_dataloader(batch_size=4, n=8, p=4)
-    model = train_acx(
-        loader,
-        p=4,
-        device="cpu",
-        epochs=1,
-        phi_dropout=0.1,
-        head_dropout=0.1,
-        disc_dropout=0.1,
-        verbose=False,
-    )
+    model_cfg = ModelConfig(p=4, phi_dropout=0.1, head_dropout=0.1, disc_dropout=0.1)
+    train_cfg = TrainingConfig(epochs=1, verbose=False)
+    model = train_acx(loader, model_cfg, train_cfg, device="cpu")
     assert any(isinstance(m, nn.Dropout) for m in model.phi.net.modules())
     assert any(isinstance(m, nn.Dropout) for m in model.mu0.net.modules())
     assert any(isinstance(m, nn.Dropout) for m in model.disc.net.modules())


### PR DESCRIPTION
## Summary
- refactor `train_acx` to accept `ModelConfig` and `TrainingConfig`
- update trainer and experiment utilities for new API
- adjust CLI, benchmarks and docs
- rewrite tests for config-based API
- fix ruff lint

## Testing
- `ruff check .`
- `black --check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6850b5be95d883248acccbe90d5a805c