### PR TITLE
Enable Ruff autofix in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Lint and auto-format
         if: matrix.python-version == '3.12' && matrix.cuda == 'cpu'
         run: |
-          ruff check .
+          ruff check --fix .
           black .
       - name: Push changes back to the branch
         if: github.event_name == 'pull_request' && matrix.python-version == '3.12' && matrix.cuda == 'cpu'
@@ -41,7 +41,7 @@ jobs:
           git config --global user.email "github-actions[bot]@users.noreply.github.com"
           if [[ $(git status --porcelain) ]]; then
             git add .
-            git commit -m "CI: auto-format Python code with black"
+            git commit -m "CI: auto-format Python code with black and ruff"
             git push
           fi
       - name: Run tests


### PR DESCRIPTION
## Summary
- enable `ruff --fix` when linting in GitHub Actions
- update auto-format commit message to mention ruff

## Testing
- `ruff check .`
- `black --check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68511cd6828883249c30ff888e4cc307