### PR TITLE
Refactor toy dataset generator

### DIFF
--- a/crosslearner/datasets/toy.py
+++ b/crosslearner/datasets/toy.py
@@ -4,7 +4,12 @@ import torch
 from torch.utils.data import TensorDataset, DataLoader
 
 
-def get_toy_dataloader(batch_size: int = 256, n: int = 8000, p: int = 10):
+def get_toy_dataloader(
+    batch_size: int = 256,
+    n: int = 8000,
+    p: int = 10,
+    seed: int | None = None,
+) -> tuple[DataLoader, tuple[torch.Tensor, torch.Tensor]]:
     """Return ``DataLoader`` with simple synthetic data.
 
     Args:
@@ -16,13 +21,14 @@ def get_toy_dataloader(batch_size: int = 256, n: int = 8000, p: int = 10):
         Tuple ``(loader, (mu0, mu1))`` where ``mu0`` and ``mu1`` are the true
         potential outcomes.
     """
-    X = torch.randn(n, p)
+    gen = torch.Generator().manual_seed(seed) if seed is not None else None
+    X = torch.randn(n, p, generator=gen)
     pi = torch.sigmoid(X[:, :2].sum(-1))
-    T = torch.bernoulli(pi).float()
+    T = torch.bernoulli(pi, generator=gen).float()
     mu0 = (X[:, 0] - X[:, 1]).unsqueeze(-1)
     mu1 = mu0 + 2.0 * torch.tanh(X[:, 2]).unsqueeze(-1)
     t_unsq = T.unsqueeze(-1)
-    Y = torch.where(t_unsq.bool(), mu1, mu0) + 0.5 * torch.randn(n, 1)
+    Y = torch.where(t_unsq.bool(), mu1, mu0) + 0.5 * torch.randn(n, 1, generator=gen)
 
     dset = TensorDataset(X, t_unsq, Y)
     loader = DataLoader(dset, batch_size=batch_size, shuffle=True)

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -1,3 +1,4 @@
+import torch
 from crosslearner.datasets.toy import get_toy_dataloader
 
 
@@ -10,3 +11,10 @@ def test_get_toy_dataloader_shapes():
     assert Y.shape == (4, 1)
     assert mu0.shape == (8, 1)
     assert mu1.shape == (8, 1)
+
+
+def test_get_toy_dataloader_seed_reproducible():
+    _, (mu0_a, mu1_a) = get_toy_dataloader(batch_size=4, n=8, p=3, seed=0)
+    _, (mu0_b, mu1_b) = get_toy_dataloader(batch_size=4, n=8, p=3, seed=0)
+    assert torch.allclose(mu0_a, mu0_b)
+    assert torch.allclose(mu1_a, mu1_b)


### PR DESCRIPTION
## Summary
- make `get_toy_dataloader` reproducible by adding an optional seed argument
- test that the toy dataset is deterministic

## Testing
- `ruff check .`
- `black --check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68511d5a0bd48324a136df3f2f75f982