### PR TITLE
Add utility for spectral normalization

### DIFF
--- a/crosslearner/training/train_acx.py
+++ b/crosslearner/training/train_acx.py
@@ -6,7 +6,7 @@ from torch.utils.tensorboard import SummaryWriter
 
 from crosslearner.training.history import EpochStats, History
 from crosslearner.evaluation.evaluate import evaluate
-from crosslearner.utils import set_seed, default_device
+from crosslearner.utils import set_seed, default_device, apply_spectral_norm
 from crosslearner.training.config import ModelConfig, TrainingConfig
 from crosslearner.training.nuisance import estimate_nuisances
 
@@ -255,9 +255,7 @@ def train_acx(
         residual=residual,
     ).to(device)
     if spectral_norm:
-        for m in model.modules():
-            if isinstance(m, nn.Linear):
-                nn.utils.spectral_norm(m)
+        apply_spectral_norm(model)
 
     if isinstance(optimizer, str):
         opt_name = optimizer.lower()

--- a/crosslearner/training/trainer.py
+++ b/crosslearner/training/trainer.py
@@ -1,14 +1,12 @@
 from __future__ import annotations
 
 from typing import Optional, Tuple
-
-import torch.nn as nn
 from torch.utils.data import DataLoader
 
 from .config import ModelConfig, TrainingConfig
 from .history import History
 from ..models.acx import ACX, _get_activation
-from ..utils import set_seed, default_device
+from ..utils import set_seed, default_device, apply_spectral_norm
 
 
 class ACXTrainer:
@@ -41,9 +39,7 @@ class ACXTrainer:
             residual=model_cfg.residual,
         ).to(self.device)
         if train_cfg.spectral_norm:
-            for m in self.model.modules():
-                if isinstance(m, nn.Linear):
-                    nn.utils.spectral_norm(m)
+            apply_spectral_norm(self.model)
 
     def train(self, loader: DataLoader) -> ACX | Tuple[ACX, History]:
         from .train_acx import train_acx

--- a/crosslearner/utils.py
+++ b/crosslearner/utils.py
@@ -3,6 +3,7 @@ import random
 
 import numpy as np
 import torch
+import torch.nn as nn
 
 
 def set_seed(seed: int, *, deterministic: bool = False) -> None:
@@ -22,3 +23,11 @@ def default_device() -> str:
     """Return the best available device string."""
 
     return "cuda" if torch.cuda.is_available() else "cpu"
+
+
+def apply_spectral_norm(model: nn.Module) -> None:
+    """Apply spectral normalization to all linear layers in ``model``."""
+
+    for module in model.modules():
+        if isinstance(module, nn.Linear):
+            nn.utils.spectral_norm(module)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -5,7 +5,7 @@ import numpy as np
 import random
 
 from crosslearner.models.acx import MLP, _get_activation
-from crosslearner.utils import set_seed, default_device
+from crosslearner.utils import set_seed, default_device, apply_spectral_norm
 
 
 def test_get_activation_invalid_name():
@@ -55,3 +55,10 @@ def test_default_device_returns_valid_string():
     dev = default_device()
     assert dev in {"cuda", "cpu"}
     assert isinstance(dev, str)
+
+
+def test_apply_spectral_norm_applies_to_linear():
+    lin = nn.Linear(2, 2)
+    model = nn.Sequential(lin)
+    apply_spectral_norm(model)
+    assert hasattr(lin, "weight_u")


### PR DESCRIPTION
## Summary
- add `apply_spectral_norm` helper
- use helper in `train_acx` and `ACXTrainer`
- test spectral norm helper

## Testing
- `ruff check .`
- `black --check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685126ca04588324a41612c23ef8c2e2