### PR TITLE
Add model_device helper function

### DIFF
--- a/crosslearner/evaluation/evaluate.py
+++ b/crosslearner/evaluation/evaluate.py
@@ -3,12 +3,13 @@
 import torch
 from crosslearner.evaluation.metrics import pehe
 from crosslearner.models.acx import ACX
+from crosslearner.utils import model_device
 
 
 def _model_outputs(model: ACX, X: torch.Tensor) -> tuple[torch.Tensor, ...]:
     """Run ``model`` on ``X`` placed on the correct device."""
 
-    device = next(model.parameters()).device
+    device = model_device(model)
     X = X.to(device)
     model.eval()
     with torch.no_grad():
@@ -36,7 +37,7 @@ def evaluate(
         The square-root PEHE value.
     """
 
-    device = next(model.parameters()).device
+    device = model_device(model)
     mu0 = mu0.to(device)
     mu1 = mu1.to(device)
 
@@ -69,7 +70,7 @@ def evaluate_ipw(
         Estimated square-root PEHE using IPW pseudo-outcomes.
     """
 
-    device = next(model.parameters()).device
+    device = model_device(model)
     T = T.to(device)
     Y = Y.to(device)
     propensity = propensity.to(device)
@@ -104,7 +105,7 @@ def evaluate_dr(
         Estimated square-root PEHE using the doubly robust pseudo-outcomes.
     """
 
-    device = next(model.parameters()).device
+    device = model_device(model)
     T = T.to(device)
     Y = Y.to(device)
     propensity = propensity.to(device)

--- a/crosslearner/utils.py
+++ b/crosslearner/utils.py
@@ -31,3 +31,12 @@ def apply_spectral_norm(model: nn.Module) -> None:
     for module in model.modules():
         if isinstance(module, nn.Linear):
             nn.utils.spectral_norm(module)
+
+
+def model_device(model: nn.Module) -> torch.device:
+    """Return the device of ``model`` or CPU if no parameters."""
+
+    try:
+        return next(model.parameters()).device
+    except StopIteration:  # pragma: no cover - unlikely
+        return torch.device("cpu")

--- a/crosslearner/visualization.py
+++ b/crosslearner/visualization.py
@@ -5,6 +5,7 @@ from matplotlib import pyplot as plt
 
 from .models.acx import ACX
 from .training.history import History
+from .utils import model_device
 
 
 def plot_losses(history: History):
@@ -39,7 +40,7 @@ def scatter_tau(model: ACX, X: torch.Tensor, mu0: torch.Tensor, mu1: torch.Tenso
     Returns:
         Matplotlib figure with a scatter plot of true vs predicted ``tau``.
     """
-    device = next(model.parameters()).device
+    device = model_device(model)
     X = X.to(device)
     mu0 = mu0.to(device)
     mu1 = mu1.to(device)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -5,7 +5,12 @@ import numpy as np
 import random
 
 from crosslearner.models.acx import MLP, _get_activation
-from crosslearner.utils import set_seed, default_device, apply_spectral_norm
+from crosslearner.utils import (
+    set_seed,
+    default_device,
+    apply_spectral_norm,
+    model_device,
+)
 
 
 def test_get_activation_invalid_name():
@@ -62,3 +67,9 @@ def test_apply_spectral_norm_applies_to_linear():
     model = nn.Sequential(lin)
     apply_spectral_norm(model)
     assert hasattr(lin, "weight_u")
+
+
+def test_model_device_returns_correct_device():
+    model = nn.Linear(1, 1)
+    dev = model_device(model)
+    assert dev == next(model.parameters()).device


### PR DESCRIPTION
## Summary
- add `model_device` helper to centralise getting the device for a model
- use `model_device` in evaluation and visualisation utilities
- test the new helper

## Testing
- `ruff check .`
- `black --check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685131d9fe3c8324b8453df18d18b944