### PR TITLE
Add tests for nuisance and download utilities

### DIFF
--- a/tests/test_download_utils.py
+++ b/tests/test_download_utils.py
@@ -1,0 +1,72 @@
+import os
+import urllib.request
+import pytest
+
+from crosslearner.datasets.utils import download_if_missing
+from crosslearner.benchmarks import run_benchmarks
+
+
+def test_download_if_missing_existing_file(tmp_path, monkeypatch):
+    path = tmp_path / "data.txt"
+    path.write_text("hi")
+    called = {"count": 0}
+
+    def fake_urlretrieve(url, p):
+        called["count"] += 1
+
+    monkeypatch.setattr(urllib.request, "urlretrieve", fake_urlretrieve)
+    returned = download_if_missing("http://example.com", str(path))
+    assert returned == str(path)
+    assert called["count"] == 0
+
+
+def test_download_if_missing_creates_file(tmp_path, monkeypatch):
+    path = tmp_path / "data.txt"
+
+    def fake_urlretrieve(url, p):
+        with open(p, "w") as f:
+            f.write("data")
+
+    monkeypatch.setattr(urllib.request, "urlretrieve", fake_urlretrieve)
+    returned = download_if_missing("http://example.com", str(path))
+    assert path.read_text() == "data"
+    assert returned == str(path)
+
+
+def test_download_if_missing_failure(tmp_path, monkeypatch):
+    path = tmp_path / "data.txt"
+
+    def fake_urlretrieve(url, p):
+        raise OSError("bad")
+
+    monkeypatch.setattr(urllib.request, "urlretrieve", fake_urlretrieve)
+    with pytest.raises(RuntimeError):
+        download_if_missing("http://example.com", str(path))
+
+
+def test_load_external_iris(monkeypatch):
+    iris_path = os.path.join(os.path.dirname(run_benchmarks.__file__), "iris.csv")
+    if os.path.exists(iris_path):
+        os.remove(iris_path)
+
+    def fake_urlretrieve(url, p):
+        with open(p, "w") as f:
+            f.write(
+                "sepal_length,sepal_width,petal_length,petal_width,species\n"
+                "1,2,3,4,0\n"
+                "2,3,4,5,1\n"
+            )
+
+    monkeypatch.setattr(urllib.request, "urlretrieve", fake_urlretrieve)
+    loader, (mu0, mu1) = run_benchmarks.load_external_iris(batch_size=1, seed=0)
+    try:
+        assert len(loader.dataset) == 2
+        X, T, Y = next(iter(loader))
+        assert X.shape == (1, 4)
+        assert T.shape == (1, 1)
+        assert Y.shape == (1, 1)
+        assert mu0.shape == (2, 1)
+        assert mu1.shape == (2, 1)
+    finally:
+        if os.path.exists(iris_path):
+            os.remove(iris_path)

--- a/tests/test_nuisance.py
+++ b/tests/test_nuisance.py
@@ -1,0 +1,30 @@
+import torch
+from crosslearner.datasets.toy import get_toy_dataloader
+from crosslearner.training.nuisance import estimate_nuisances
+
+
+def test_estimate_nuisances_output_shapes():
+    loader, _ = get_toy_dataloader(batch_size=8, n=16, p=3, seed=0)
+    X = torch.cat([b[0] for b in loader])
+    T = torch.cat([b[1] for b in loader])
+    Y = torch.cat([b[2] for b in loader])
+    e_hat, mu0_hat, mu1_hat = estimate_nuisances(
+        X,
+        T,
+        Y,
+        folds=2,
+        lr=1e-2,
+        batch=8,
+        propensity_epochs=1,
+        outcome_epochs=1,
+        early_stop=1,
+        device="cpu",
+        seed=0,
+    )
+    assert e_hat.shape == T.shape
+    assert mu0_hat.shape == Y.shape
+    assert mu1_hat.shape == Y.shape
+    # predictions should not all be identical
+    assert e_hat.std() > 0
+    assert mu0_hat.std() > 0
+    assert mu1_hat.std() > 0


### PR DESCRIPTION
## Summary
- add new unit test for `estimate_nuisances`
- cover dataset helpers `download_if_missing` and the `load_external_iris` loader

## Testing
- `ruff check .`
- `black --check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6851ea79cf58832493e85ef8cf32202b