### PR TITLE
Improve Sphinx docs

### DIFF
--- a/docs/api/modules.rst
+++ b/docs/api/modules.rst
@@ -1,7 +1,8 @@
 crosslearner
 ============
 
-.. toctree::
-   :maxdepth: 4
+.. autosummary::
+   :toctree: generated/api
+   :recursive:
 
    crosslearner

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -23,7 +23,21 @@ release = "0.1"
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration
 
-extensions = ["sphinx.ext.autodoc", "sphinx.ext.napoleon"]
+extensions = [
+    "sphinx.ext.autodoc",
+    "sphinx.ext.napoleon",
+    "sphinx.ext.autosummary",
+    "sphinx.ext.viewcode",
+    "sphinx.ext.autosectionlabel",
+    "sphinx.ext.intersphinx",
+]
+
+autosummary_generate = True
+autosectionlabel_prefix_document = True
+intersphinx_mapping = {
+    "python": ("https://docs.python.org/3", {}),
+    "torch": ("https://pytorch.org/docs/stable", {}),
+}
 
 templates_path = ["_templates"]
 exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
@@ -32,5 +46,5 @@ exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
 # -- Options for HTML output -------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output
 
-html_theme = "alabaster"
+html_theme = "furo"
 html_static_path = ["_static"]

--- a/docs/datasets.rst
+++ b/docs/datasets.rst
@@ -1,0 +1,24 @@
+Datasets
+========
+
+``crosslearner`` ships with several datasets used for benchmarking and
+experimentation. Each dataset is available through a loader function in
+:mod:`crosslearner.datasets` that returns a ``DataLoader`` and ground
+truth outcomes where applicable.
+
+Available loaders
+-----------------
+
+.. autosummary::
+   :toctree: generated/datasets
+
+   crosslearner.datasets.get_toy_dataloader
+   crosslearner.datasets.get_complex_dataloader
+   crosslearner.datasets.get_confounding_dataloader
+   crosslearner.datasets.get_ihdp_dataloader
+   crosslearner.datasets.get_jobs_dataloader
+   crosslearner.datasets.get_acic2016_dataloader
+   crosslearner.datasets.get_acic2018_dataloader
+   crosslearner.datasets.get_twins_dataloader
+   crosslearner.datasets.get_lalonde_dataloader
+   crosslearner.datasets.get_aircraft_dataloader

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -10,9 +10,11 @@ the training procedure, hyperparameter sweeps and available modules.
    :maxdepth: 2
    :caption: Contents:
 
+   quickstart
    theory
    hyperparameter_sweeps
    usage_examples
+   datasets
 
 
 .. toctree::

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -1,0 +1,26 @@
+Quickstart
+==========
+
+Follow these steps to install ``crosslearner`` and train your first model.
+
+Installation
+------------
+
+Install the package from source using ``pip``:
+
+.. code-block:: bash
+
+   pip install .
+
+Minimal example
+---------------
+
+Run the command line entry point to train on a toy dataset and
+report :math:`\sqrt{\mathrm{PEHE}}`:
+
+.. code-block:: bash
+
+   crosslearner-train
+
+This launches a short training loop and prints the final metric.
+Loss histories are logged to TensorBoard when available.

--- a/docs/usage_examples.rst
+++ b/docs/usage_examples.rst
@@ -43,6 +43,14 @@ model on the toy dataset and computes the final PEHE:
    pehe = evaluate(model, X, mu0, mu1)
    print("sqrt(PEHE)", pehe)
 
+Step-by-step notebook
+---------------------
+
+For a more interactive introduction open the ``examples/notebook.ipynb``
+Jupyter notebook which walks through data loading, model creation and
+evaluation step by step.  The notebook links back to :doc:`theory` for
+explanations of the underlying objective.
+
 Experiment manager
 ------------------
 


### PR DESCRIPTION
## Summary
- use `furo` theme and enable autosummary, viewcode, autosectionlabel and intersphinx
- add Quickstart and datasets pages
- link new docs from index page
- generate API docs via autosummary
- extend usage examples with notebook link

## Testing
- `ruff check .`
- `black --check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6851ea5dc8ec83248f11cc56544e9c30