### PR TITLE
Add granular residual connection flags

### DIFF
--- a/crosslearner/models/acx.py
+++ b/crosslearner/models/acx.py
@@ -119,6 +119,9 @@ class ACX(nn.Module):
         head_dropout: float = 0.0,
         disc_dropout: float = 0.0,
         residual: bool = False,
+        phi_residual: bool | None = None,
+        head_residual: bool | None = None,
+        disc_residual: bool | None = None,
     ) -> None:
         """Instantiate the model.
 
@@ -133,17 +136,26 @@ class ACX(nn.Module):
             head_dropout: Dropout probability for the outcome and effect heads.
             disc_dropout: Dropout probability for the discriminator.
             residual: Enable residual connections in all MLPs.
+            phi_residual: Override residual connections just for ``phi``.
+            head_residual: Override residual connections for outcome and effect
+                heads.
+            disc_residual: Override residual connections for the discriminator.
         """
 
         super().__init__()
         act_fn = _get_activation(activation)
+
+        phi_residual = residual if phi_residual is None else phi_residual
+        head_residual = residual if head_residual is None else head_residual
+        disc_residual = residual if disc_residual is None else disc_residual
+
         self.phi = MLP(
             p,
             rep_dim,
             hidden=phi_layers,
             activation=act_fn,
             dropout=phi_dropout,
-            residual=residual,
+            residual=phi_residual,
         )
         self.mu0 = MLP(
             rep_dim,
@@ -151,7 +163,7 @@ class ACX(nn.Module):
             hidden=head_layers,
             activation=act_fn,
             dropout=head_dropout,
-            residual=residual,
+            residual=head_residual,
         )
         self.mu1 = MLP(
             rep_dim,
@@ -159,7 +171,7 @@ class ACX(nn.Module):
             hidden=head_layers,
             activation=act_fn,
             dropout=head_dropout,
-            residual=residual,
+            residual=head_residual,
         )
         self.tau = MLP(
             rep_dim,
@@ -167,7 +179,7 @@ class ACX(nn.Module):
             hidden=head_layers,
             activation=act_fn,
             dropout=head_dropout,
-            residual=residual,
+            residual=head_residual,
         )
         self.disc = MLP(
             rep_dim + 2,
@@ -175,7 +187,7 @@ class ACX(nn.Module):
             hidden=disc_layers,
             activation=act_fn,
             dropout=disc_dropout,
-            residual=residual,
+            residual=disc_residual,
         )
 
     def forward(self, x: torch.Tensor) -> tuple[torch.Tensor, ...]:

--- a/crosslearner/training/config.py
+++ b/crosslearner/training/config.py
@@ -21,6 +21,9 @@ class ModelConfig:
     head_dropout: float = 0.0
     disc_dropout: float = 0.0
     residual: bool = False
+    phi_residual: bool | None = None
+    head_residual: bool | None = None
+    disc_residual: bool | None = None
 
 
 @dataclass

--- a/crosslearner/training/train_acx.py
+++ b/crosslearner/training/train_acx.py
@@ -24,6 +24,9 @@ def train_acx(
     head_dropout: float = 0.0,
     disc_dropout: float = 0.0,
     residual: bool = False,
+    phi_residual: bool | None = None,
+    head_residual: bool | None = None,
+    disc_residual: bool | None = None,
     device: Optional[str] = None,
     seed: int | None = None,
     epochs: int = 30,
@@ -82,6 +85,9 @@ def train_acx(
             head_dropout=head_dropout,
             disc_dropout=disc_dropout,
             residual=residual,
+            phi_residual=phi_residual,
+            head_residual=head_residual,
+            disc_residual=disc_residual,
         )
     elif model_config.p != p:
         raise ValueError("p does not match model_config.p")

--- a/crosslearner/training/trainer.py
+++ b/crosslearner/training/trainer.py
@@ -44,6 +44,9 @@ class ACXTrainer:
             head_dropout=model_cfg.head_dropout,
             disc_dropout=model_cfg.disc_dropout,
             residual=model_cfg.residual,
+            phi_residual=model_cfg.phi_residual,
+            head_residual=model_cfg.head_residual,
+            disc_residual=model_cfg.disc_residual,
         ).to(self.device)
         if train_cfg.spectral_norm:
             apply_spectral_norm(self.model)

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -36,6 +36,15 @@ def test_acx_dropout_layers():
 
 def test_acx_residual_option():
     model = ACX(p=3, residual=True)
+    assert model.phi.residual is True
+    assert model.mu0.residual is True
     X = torch.randn(2, 3)
     h, _, _, _ = model(X)
     assert h.shape[0] == 2
+
+
+def test_acx_partial_residual():
+    model = ACX(p=3, phi_residual=True, head_residual=False, disc_residual=False)
+    assert model.phi.residual is True
+    assert model.mu0.residual is False
+    assert model.disc.residual is False


### PR DESCRIPTION
## Summary
- allow per-module residual connections in ACX
- expose residual flags via train_acx and ModelConfig
- pass through flags in ACXTrainer
- test partial residual configuration

## Testing
- `ruff check .`
- `black --check .`
- `pytest --cov=crosslearner --cov-report=xml -q`

------
https://chatgpt.com/codex/tasks/task_e_68521eae726483248ff47ffdc4b643c7