### PR TITLE
Refactor train_acx to use config objects

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ import optuna
 import torch
 from crosslearner.datasets.toy import get_toy_dataloader
 from crosslearner.training.train_acx import train_acx
+from crosslearner.training import ModelConfig, TrainingConfig
 from crosslearner.evaluation.evaluate import evaluate
 
 loader, (mu0, mu1) = get_toy_dataloader()
@@ -89,16 +90,18 @@ mu0_all = mu0
 mu1_all = mu1
 
 def objective(trial):
+    model_cfg = ModelConfig(
+        p=10,
+        rep_dim=trial.suggest_int("rep_dim", 32, 128),
+    )
+    train_cfg = TrainingConfig(
+        epochs=30,
+        lr_g=trial.suggest_loguniform("lr_g", 1e-4, 1e-2),
+        lr_d=trial.suggest_loguniform("lr_d", 1e-4, 1e-2),
+        beta_cons=trial.suggest_float("beta_cons", 1.0, 20.0),
+    )
     return evaluate(
-        train_acx(
-            loader,
-            p=10,
-            rep_dim=trial.suggest_int("rep_dim", 32, 128),
-            lr_g=trial.suggest_loguniform("lr_g", 1e-4, 1e-2),
-            lr_d=trial.suggest_loguniform("lr_d", 1e-4, 1e-2),
-            beta_cons=trial.suggest_float("beta_cons", 1.0, 20.0),
-            epochs=30,
-        ),
+        train_acx(loader, model_cfg, train_cfg),
         X,
         mu0_all,
         mu1_all,

--- a/crosslearner/__main__.py
+++ b/crosslearner/__main__.py
@@ -6,6 +6,7 @@ from crosslearner.utils import set_seed, default_device
 
 from crosslearner.datasets.toy import get_toy_dataloader
 from crosslearner.training.train_acx import train_acx
+from crosslearner.training import ModelConfig, TrainingConfig
 from crosslearner.evaluation.evaluate import evaluate
 
 
@@ -14,7 +15,9 @@ def main() -> None:
     set_seed(0)
     loader, (mu0, mu1) = get_toy_dataloader()
     device = default_device()
-    model = train_acx(loader, p=10, device=device)
+    model_cfg = ModelConfig(p=10)
+    train_cfg = TrainingConfig()
+    model = train_acx(loader, model_cfg, train_cfg, device=device)
     X = torch.cat([b[0] for b in loader]).to(device)
     mu0_all = mu0.to(device)
     mu1_all = mu1.to(device)

--- a/crosslearner/benchmarks/run_benchmarks.py
+++ b/crosslearner/benchmarks/run_benchmarks.py
@@ -19,6 +19,7 @@ from crosslearner.datasets.twins import get_twins_dataloader
 from crosslearner.datasets.lalonde import get_lalonde_dataloader
 from crosslearner.datasets.synthetic import get_confounding_dataloader
 from crosslearner.training.train_acx import train_acx
+from crosslearner.training import ModelConfig, TrainingConfig
 from crosslearner.models.baselines import DRLearner, SLearner, TLearner, XLearner
 from crosslearner.evaluation.evaluate import evaluate, evaluate_dr
 from crosslearner.evaluation.metrics import (
@@ -190,7 +191,9 @@ def run(
         set_seed(seed)
         loader, (mu0, mu1) = loader_fn(seed)
         p = loader.dataset.tensors[0].size(1)
-        model = train_acx(loader, p=p, epochs=epochs, seed=seed)
+        model_cfg = ModelConfig(p=p)
+        train_cfg = TrainingConfig(epochs=epochs)
+        model = train_acx(loader, model_cfg, train_cfg, seed=seed)
         X = torch.cat([b[0] for b in loader])
         T_all = torch.cat([b[1] for b in loader])
         Y_all = torch.cat([b[2] for b in loader])

--- a/crosslearner/training/train_acx.py
+++ b/crosslearner/training/train_acx.py
@@ -1,7 +1,8 @@
-import torch
-import torch.nn as nn
+from __future__ import annotations
+
+from typing import Optional
+
 from torch.utils.data import DataLoader
-from typing import Callable, Iterable, Optional, Tuple, Type
 
 from .config import ModelConfig, TrainingConfig
 from .trainer import ACXTrainer
@@ -11,125 +12,13 @@ from ..models.acx import ACX
 
 def train_acx(
     loader: DataLoader,
-    p: int,
+    model_config: ModelConfig,
+    training_config: TrainingConfig,
     *,
-    model_config: ModelConfig | None = None,
-    training_config: TrainingConfig | None = None,
-    rep_dim: int = 64,
-    phi_layers: Iterable[int] | None = (128,),
-    head_layers: Iterable[int] | None = (64,),
-    disc_layers: Iterable[int] | None = (64,),
-    activation: str | Callable[[], nn.Module] = "relu",
-    phi_dropout: float = 0.0,
-    head_dropout: float = 0.0,
-    disc_dropout: float = 0.0,
-    residual: bool = False,
-    phi_residual: bool | None = None,
-    head_residual: bool | None = None,
-    disc_residual: bool | None = None,
     device: Optional[str] = None,
     seed: int | None = None,
-    epochs: int = 30,
-    alpha_out: float = 1.0,
-    beta_cons: float = 10.0,
-    gamma_adv: float = 1.0,
-    lr_g: float = 1e-3,
-    lr_d: float = 1e-3,
-    optimizer: str | Type[torch.optim.Optimizer] = "adam",
-    opt_g_kwargs: dict | None = None,
-    opt_d_kwargs: dict | None = None,
-    lr_scheduler: str | Type[torch.optim.lr_scheduler._LRScheduler] | None = None,
-    sched_g_kwargs: dict | None = None,
-    sched_d_kwargs: dict | None = None,
-    grad_clip: float = 2.0,
-    warm_start: int = 0,
-    use_wgan_gp: bool = False,
-    spectral_norm: bool = False,
-    feature_matching: bool = False,
-    label_smoothing: bool = False,
-    instance_noise: bool = False,
-    gradient_reversal: bool = False,
-    ttur: bool = False,
-    lambda_gp: float = 10.0,
-    eta_fm: float = 5.0,
-    grl_weight: float = 1.0,
-    tensorboard_logdir: Optional[str] = None,
-    weight_clip: Optional[float] = None,
-    val_data: Optional[Tuple[torch.Tensor, torch.Tensor, torch.Tensor]] = None,
-    risk_data: Optional[Tuple[torch.Tensor, torch.Tensor, torch.Tensor]] = None,
-    risk_folds: int = 5,
-    nuisance_propensity_epochs: int = 500,
-    nuisance_outcome_epochs: int = 3,
-    nuisance_early_stop: int = 10,
-    patience: int = 0,
-    verbose: bool = True,
-    return_history: bool = False,
 ) -> ACX | tuple[ACX, History]:
-    """Train AC-X model with optional GAN tricks.
-
-    This function preserves the original ``train_acx`` signature but delegates
-    all heavy lifting to :class:`ACXTrainer`. When ``model_config`` or
-    ``training_config`` are supplied, the respective keyword arguments are
-    ignored.
-    """
-
-    if model_config is None:
-        model_config = ModelConfig(
-            p=p,
-            rep_dim=rep_dim,
-            phi_layers=phi_layers,
-            head_layers=head_layers,
-            disc_layers=disc_layers,
-            activation=activation,
-            phi_dropout=phi_dropout,
-            head_dropout=head_dropout,
-            disc_dropout=disc_dropout,
-            residual=residual,
-            phi_residual=phi_residual,
-            head_residual=head_residual,
-            disc_residual=disc_residual,
-        )
-    elif model_config.p != p:
-        raise ValueError("p does not match model_config.p")
-
-    if training_config is None:
-        training_config = TrainingConfig(
-            epochs=epochs,
-            alpha_out=alpha_out,
-            beta_cons=beta_cons,
-            gamma_adv=gamma_adv,
-            lr_g=lr_g,
-            lr_d=lr_d,
-            optimizer=optimizer,
-            opt_g_kwargs=opt_g_kwargs or {},
-            opt_d_kwargs=opt_d_kwargs or {},
-            lr_scheduler=lr_scheduler,
-            sched_g_kwargs=sched_g_kwargs or {},
-            sched_d_kwargs=sched_d_kwargs or {},
-            grad_clip=grad_clip,
-            warm_start=warm_start,
-            use_wgan_gp=use_wgan_gp,
-            spectral_norm=spectral_norm,
-            feature_matching=feature_matching,
-            label_smoothing=label_smoothing,
-            instance_noise=instance_noise,
-            gradient_reversal=gradient_reversal,
-            ttur=ttur,
-            lambda_gp=lambda_gp,
-            eta_fm=eta_fm,
-            grl_weight=grl_weight,
-            tensorboard_logdir=tensorboard_logdir,
-            weight_clip=weight_clip,
-            val_data=val_data,
-            risk_data=risk_data,
-            risk_folds=risk_folds,
-            nuisance_propensity_epochs=nuisance_propensity_epochs,
-            nuisance_outcome_epochs=nuisance_outcome_epochs,
-            nuisance_early_stop=nuisance_early_stop,
-            patience=patience,
-            verbose=verbose,
-            return_history=return_history,
-        )
+    """Train an ACX model using configuration objects."""
 
     trainer = ACXTrainer(model_config, training_config, device=device, seed=seed)
     return trainer.train(loader)

--- a/docs/hyperparameter_sweeps.rst
+++ b/docs/hyperparameter_sweeps.rst
@@ -14,6 +14,7 @@ The snippet below sweeps a few hyperparameters and minimises the validation
    import torch
    from crosslearner.datasets.toy import get_toy_dataloader
    from crosslearner.training.train_acx import train_acx
+   from crosslearner.training import ModelConfig, TrainingConfig
    from crosslearner.evaluation import evaluate
 
    loader, (mu0, mu1) = get_toy_dataloader()
@@ -27,16 +28,14 @@ The snippet below sweeps a few hyperparameters and minimises the validation
        lr_d = trial.suggest_loguniform("lr_d", 1e-4, 1e-2)
        beta_cons = trial.suggest_float("beta_cons", 1.0, 20.0)
 
-       model = train_acx(
-           loader,
-           p=10,
-           rep_dim=rep_dim,
+       model_cfg = ModelConfig(p=10, rep_dim=rep_dim)
+       train_cfg = TrainingConfig(
+           epochs=30,
            lr_g=lr_g,
            lr_d=lr_d,
            beta_cons=beta_cons,
-           epochs=30,
-           device="cpu",
        )
+       model = train_acx(loader, model_cfg, train_cfg, device="cpu")
        return evaluate(model, X, mu0_all, mu1_all)
 
    study = optuna.create_study(direction="minimize")

--- a/docs/usage_examples.rst
+++ b/docs/usage_examples.rst
@@ -31,6 +31,7 @@ model on the toy dataset and computes the final PEHE:
 
    from crosslearner.datasets.toy import get_toy_dataloader
    from crosslearner.training.train_acx import train_acx
+   from crosslearner.training import ModelConfig, TrainingConfig
    from crosslearner.evaluation import evaluate
    from crosslearner import set_seed
    import torch
@@ -39,7 +40,9 @@ model on the toy dataset and computes the final PEHE:
    loader, (mu0, mu1) = get_toy_dataloader()
    X = torch.cat([b[0] for b in loader])
 
-   model = train_acx(loader, p=10, epochs=30)
+   model_cfg = ModelConfig(p=10)
+   train_cfg = TrainingConfig(epochs=30)
+   model = train_acx(loader, model_cfg, train_cfg)
    pehe = evaluate(model, X, mu0, mu1)
    print("sqrt(PEHE)", pehe)
 

--- a/tests/test_experiment_manager.py
+++ b/tests/test_experiment_manager.py
@@ -1,19 +1,22 @@
 import optuna
 from crosslearner.datasets.toy import get_toy_dataloader
 from crosslearner.experiments import ExperimentManager, cross_validate_acx
+from crosslearner.training import ModelConfig, TrainingConfig
 
 
 def test_cross_validate(tmp_path):
     loader, (mu0, mu1) = get_toy_dataloader(batch_size=4, n=16, p=3)
+    model_cfg = ModelConfig(p=3)
+    train_cfg = TrainingConfig(epochs=1)
     metric = cross_validate_acx(
         loader,
         mu0,
         mu1,
-        p=3,
+        model_config=model_cfg,
+        training_config=train_cfg,
         folds=2,
         device="cpu",
         log_dir=str(tmp_path),
-        epochs=1,
     )
     assert metric >= 0.0
     assert (tmp_path / "fold_0").exists()

--- a/train.py
+++ b/train.py
@@ -5,6 +5,7 @@ import torch
 from crosslearner.utils import set_seed, default_device
 from crosslearner.datasets.toy import get_toy_dataloader
 from crosslearner.training.train_acx import train_acx
+from crosslearner.training import ModelConfig, TrainingConfig
 from crosslearner.evaluation.evaluate import evaluate
 
 
@@ -14,7 +15,9 @@ def main():
     set_seed(0)
     loader, (mu0, mu1) = get_toy_dataloader()
     device = default_device()
-    model = train_acx(loader, p=10, device=device)
+    model_cfg = ModelConfig(p=10)
+    train_cfg = TrainingConfig()
+    model = train_acx(loader, model_cfg, train_cfg, device=device)
     X = torch.cat([b[0] for b in loader]).to(device)
     mu0_all = mu0.to(device)
     mu1_all = mu1.to(device)


### PR DESCRIPTION
## Summary
- remove legacy keyword arguments from `train_acx`
- update CLI, training utilities and docs to pass `ModelConfig` and `TrainingConfig`
- adapt experiment manager helpers for the new configs
- update tests to the new API
- avoid a SyntaxWarning in `cross_validate_acx` by using a raw docstring

## Testing
- `ruff check .`
- `black --check .`
- `pytest --cov=crosslearner --cov-report=xml -q`


------
https://chatgpt.com/codex/tasks/task_e_685222f63cec83248d371ca3354640f9