### PR TITLE
Add Optuna sweep CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,3 +12,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Baseline MLPRegressors now train until convergence
 - Added hinge and least-squares GAN losses via `adv_loss` option
 - Added exponential moving average (`ema_decay`) for generator parameters
+- Added `crosslearner-sweep` command to run Optuna hyperparameter searches

--- a/README.md
+++ b/README.md
@@ -111,6 +111,16 @@ study = optuna.create_study(direction="minimize")
 study.optimize(objective, n_trials=50)
 ```
 
+The command-line entry ``crosslearner-sweep`` wraps this workflow. It runs a
+sweep on one of the built-in datasets using a YAML file that describes the
+search space:
+
+```bash
+crosslearner-sweep toy --trials 10 --sampler random
+```
+
+Pass ``--config my_space.yaml`` to override the default ranges.
+
 See :doc:`hyperparameter_sweeps` in the documentation for more details.
 
 ## Experiment Manager

--- a/crosslearner/__init__.py
+++ b/crosslearner/__init__.py
@@ -5,6 +5,7 @@ from .training.train_acx import train_acx
 from .training.history import EpochStats, History
 from .evaluation.evaluate import evaluate
 from .experiments import ExperimentManager, cross_validate_acx
+from .experiments.sweep import run_sweep
 from .utils import set_seed, default_device
 from .visualization import (
     plot_losses,
@@ -30,6 +31,7 @@ __all__ = [
     "plot_residuals",
     "ExperimentManager",
     "cross_validate_acx",
+    "run_sweep",
     "set_seed",
     "default_device",
 ]

--- a/crosslearner/configs/optuna_sweep.yaml
+++ b/crosslearner/configs/optuna_sweep.yaml
@@ -1,0 +1,20 @@
+rep_dim:
+  type: int
+  low: 32
+  high: 64
+lr_g:
+  type: loguniform
+  low: 1e-4
+  high: 1e-2
+lr_d:
+  type: loguniform
+  low: 1e-4
+  high: 1e-2
+beta_cons:
+  type: float
+  low: 1.0
+  high: 20.0
+epochs:
+  type: int
+  low: 1
+  high: 2

--- a/crosslearner/experiments/manager.py
+++ b/crosslearner/experiments/manager.py
@@ -133,6 +133,7 @@ class ExperimentManager:
         *,
         n_trials: int = 50,
         direction: str = "minimize",
+        sampler: "optuna.samplers.BaseSampler | None" = None,
     ) -> "optuna.Study":
         """Run an Optuna search over ``n_trials`` using ``space_fn``.
 
@@ -177,6 +178,6 @@ class ExperimentManager:
                 seed=self.seed,
             )
 
-        study = optuna.create_study(direction=direction)
+        study = optuna.create_study(direction=direction, sampler=sampler)
         study.optimize(objective, n_trials=n_trials)
         return study

--- a/crosslearner/experiments/sweep.py
+++ b/crosslearner/experiments/sweep.py
@@ -1,0 +1,108 @@
+import argparse
+import os
+from typing import Callable, Dict, Any, Optional
+
+import yaml
+import optuna
+
+from .manager import ExperimentManager
+from ..benchmarks.run_benchmarks import DATASET_LOADERS
+
+
+_DEFAULT_SPACE = os.path.join(os.path.dirname(__file__), "../configs/optuna_sweep.yaml")
+
+
+def _load_space(path: str) -> Callable[[optuna.Trial], Dict[str, Any]]:
+    with open(path) as f:
+        cfg = yaml.safe_load(f) or {}
+
+    def space(trial: optuna.Trial) -> Dict[str, Any]:
+        params: Dict[str, Any] = {}
+        for name, spec in cfg.items():
+            typ = spec.get("type", "float")
+            if typ == "int":
+                params[name] = trial.suggest_int(name, spec["low"], spec["high"])
+            elif typ == "float":
+                params[name] = trial.suggest_float(name, spec["low"], spec["high"])
+            elif typ == "loguniform":
+                params[name] = trial.suggest_float(
+                    name, spec["low"], spec["high"], log=True
+                )
+            elif typ == "choice":
+                params[name] = trial.suggest_categorical(name, spec["values"])
+            elif typ == "bool":
+                params[name] = trial.suggest_categorical(name, [True, False])
+            else:  # pragma: no cover - unexpected
+                raise ValueError(f"unknown parameter type {typ}")
+        return params
+
+    return space
+
+
+def run_sweep(
+    dataset: str,
+    *,
+    n_trials: int = 50,
+    sampler: str | optuna.samplers.BaseSampler = "tpe",
+    space_config: Optional[str] = None,
+) -> optuna.Study:
+    """Run an Optuna sweep over ``dataset`` using ``n_trials``.
+
+    Args:
+        dataset: Name of the dataset as understood by ``crosslearner-benchmarks``.
+        n_trials: Number of trials to evaluate.
+        sampler: Sampler name ("tpe" or "random") or an Optuna sampler instance.
+        space_config: Optional path to a YAML file describing the search space.
+    """
+    if dataset not in DATASET_LOADERS:
+        raise ValueError(f"unknown dataset {dataset}")
+
+    loader_fn = DATASET_LOADERS[dataset]
+    loader, (mu0, mu1) = loader_fn(0)
+    p = loader.dataset.tensors[0].size(1)
+    manager = ExperimentManager(loader, mu0, mu1, p=p, folds=3, device="cpu")
+
+    space_fn = _load_space(space_config or _DEFAULT_SPACE)
+
+    if isinstance(sampler, str):
+        name = sampler.lower()
+        if name == "tpe":
+            sampler_obj = optuna.samplers.TPESampler()
+        elif name == "random":
+            sampler_obj = optuna.samplers.RandomSampler()
+        else:  # pragma: no cover - unexpected
+            raise ValueError(f"unknown sampler {sampler}")
+    else:
+        sampler_obj = sampler
+
+    return manager.optimize(space_fn, n_trials=n_trials, sampler=sampler_obj)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Run Optuna sweep for ACX")
+    parser.add_argument(
+        "dataset",
+        choices=list(DATASET_LOADERS.keys()),
+        help="dataset to run the sweep on",
+    )
+    parser.add_argument("--trials", type=int, default=50, help="number of trials")
+    parser.add_argument(
+        "--sampler",
+        default="tpe",
+        help="Optuna sampler to use (tpe|random)",
+    )
+    parser.add_argument(
+        "--config",
+        help="YAML file specifying search space",
+    )
+    args = parser.parse_args()
+    run_sweep(
+        args.dataset,
+        n_trials=args.trials,
+        sampler=args.sampler,
+        space_config=args.config,
+    )
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ dependencies = [
 crosslearner-train = "crosslearner.__main__:main"
 crosslearner-benchmarks = "crosslearner.benchmarks.run_benchmarks:main"
 crosslearner-benchmark = "crosslearner.benchmarks.run_benchmarks:main_baselines"
+crosslearner-sweep = "crosslearner.experiments.sweep:main"
 
 [tool.setuptools.packages.find]
 where = ["."]

--- a/tests/test_sweep.py
+++ b/tests/test_sweep.py
@@ -1,0 +1,14 @@
+from crosslearner.datasets.toy import get_toy_dataloader
+from crosslearner.experiments.sweep import run_sweep
+import crosslearner.benchmarks.run_benchmarks as rb_module
+
+
+def test_run_sweep(monkeypatch, tmp_path):
+    loader, data = get_toy_dataloader(batch_size=4, n=16, p=3)
+    rb_module.DATASET_LOADERS["toy"] = lambda seed=0: (loader, data)
+    space = tmp_path / "space.yaml"
+    space.write_text(
+        "rep_dim:\n  type: int\n  low: 4\n  high: 8\nepochs:\n  type: int\n  low: 1\n  high: 1\n"
+    )
+    study = run_sweep("toy", n_trials=1, sampler="random", space_config=str(space))
+    assert len(study.trials) == 1


### PR DESCRIPTION
## Summary
- add `crosslearner-sweep` command line entry point for Optuna sweeps
- implement sweep runner and default search space
- expose `run_sweep` in package API
- update README and changelog
- add tests for new sweep runner

## Testing
- `ruff check .`
- `black --check .`
- `pytest --cov=crosslearner --cov-report=xml -q`

------
https://chatgpt.com/codex/tasks/task_e_685266a751c48324bb91f37da1dee045