### PR TITLE
Fix baseline benchmark predictions

### DIFF
--- a/crosslearner/benchmarks/run_benchmarks.py
+++ b/crosslearner/benchmarks/run_benchmarks.py
@@ -103,8 +103,8 @@ def _baseline_mus(model, X: np.ndarray) -> tuple[torch.Tensor, torch.Tensor]:
         mu1 = model._predict_mu1(X)
         mu0 = model._predict_mu0(X)
     elif isinstance(model, XLearner):
-        mu1 = model.t.model_t.predict(X)
-        mu0 = model.t.model_c.predict(X)
+        mu1 = model.t._predict_mu1(X)
+        mu0 = model.t._predict_mu0(X)
     elif isinstance(model, DRLearner):
         mu0 = model.model_mu0.predict(X)
         mu1 = model.model_mu1.predict(X)


### PR DESCRIPTION
## Summary
- call the internal TLearner prediction helpers in `_baseline_mus`
  so benchmarks handle unfitted base models correctly

## Testing
- `ruff check .`
- `black --check .`
- `pytest --cov=crosslearner --cov-report=xml -q`

------
https://chatgpt.com/codex/tasks/task_e_68527bbd2f50832496a056f4ee35869e