### PR TITLE
Fix early stopping behavior in nuisance estimation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,3 +14,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added hinge and least-squares GAN losses via `adv_loss` option
 - Added exponential moving average (`ema_decay`) for generator parameters
 - Added R1/R2 regularization and unrolled discriminator updates
+- Early stopping in `estimate_nuisances` can now be disabled by
+  passing ``early_stop=0`` or a negative value


### PR DESCRIPTION
## Summary
- allow disabling early stopping in `estimate_nuisances`
- document the new behaviour in CHANGELOG

## Testing
- `ruff check .`
- `black --check .`
- `pytest --cov=crosslearner --cov-report=xml -q`

------
https://chatgpt.com/codex/tasks/task_e_68527bceef288324a7eddf165a1e16ff