### PR TITLE
Add causal consistency metrics and serving API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,3 +15,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added exponential moving average (`ema_decay`) for generator parameters
 - Added R1/R2 regularization and unrolled discriminator updates
 - Fixed `set_seed` to skip `torch.cuda.manual_seed_all` when CUDA is unavailable
+- Added causal consistency evaluation metrics and serving helpers

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ crosslearner-benchmark = "crosslearner.benchmarks.run_benchmarks:main_baselines"
 
 [tool.setuptools.packages.find]
 where = ["."]
-include = ["crosslearner*", "train"]
+include = ["crosslearner*", "train", "causal_consistency_nn*"]
 
 [project.optional-dependencies]
 docs = [

--- a/src/causal_consistency_nn/__init__.py
+++ b/src/causal_consistency_nn/__init__.py
@@ -1,0 +1,14 @@
+"""Simple utilities for causal consistency neural networks."""
+
+from .metrics import average_treatment_effect, gaussian_log_likelihood
+from .eval import evaluate
+from .serve import predict_z, counterfactual_z, impute_y
+
+__all__ = [
+    "average_treatment_effect",
+    "gaussian_log_likelihood",
+    "evaluate",
+    "predict_z",
+    "counterfactual_z",
+    "impute_y",
+]

--- a/src/causal_consistency_nn/eval.py
+++ b/src/causal_consistency_nn/eval.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+from typing import Dict
+
+import torch
+from torch.utils.data import DataLoader
+
+from .metrics import average_treatment_effect, gaussian_log_likelihood
+
+
+def _device(model: torch.nn.Module) -> torch.device:
+    try:
+        return next(model.parameters()).device
+    except StopIteration:  # pragma: no cover
+        return torch.device("cpu")
+
+
+def evaluate(
+    model: torch.nn.Module, loader: DataLoader, *, device: str | None = None
+) -> Dict[str, float]:
+    """Compute ATE and log-likelihood metrics for ``model`` on ``loader``.
+
+    The ``model`` is expected to return at least ``(mu0, mu1)`` when called on
+    a batch of covariates. Additional outputs are ignored.
+    """
+    device = device or _device(model)
+    mu0_list: list[torch.Tensor] = []
+    mu1_list: list[torch.Tensor] = []
+    ll_values: list[float] = []
+
+    model.eval()
+    with torch.no_grad():
+        for xb, tb, yb in loader:
+            xb = xb.to(device)
+            tb = tb.to(device)
+            yb = yb.to(device)
+
+            out = model(xb)
+            if isinstance(out, (tuple, list)):
+                if len(out) >= 3:
+                    mu0, mu1 = out[1], out[2]
+                else:
+                    mu0, mu1 = out[:2]
+            else:
+                raise ValueError(
+                    "model output must be tuple/list containing mu0 and mu1"
+                )
+
+            mu0_list.append(mu0.cpu())
+            mu1_list.append(mu1.cpu())
+            pred_y = torch.where(tb.bool(), mu1, mu0)
+            ll = gaussian_log_likelihood(yb, pred_y, torch.ones_like(pred_y))
+            ll_values.append(ll)
+
+    mu0_all = torch.cat(mu0_list)
+    mu1_all = torch.cat(mu1_list)
+    ate = average_treatment_effect(mu0_all, mu1_all)
+    ll_mean = float(sum(ll_values) / len(ll_values)) if ll_values else float("nan")
+    return {"ate": ate, "log_likelihood": ll_mean}

--- a/src/causal_consistency_nn/metrics.py
+++ b/src/causal_consistency_nn/metrics.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+import torch
+
+
+def average_treatment_effect(mu0: torch.Tensor, mu1: torch.Tensor) -> float:
+    """Return the Average Treatment Effect (ATE).
+
+    Args:
+        mu0: Potential outcomes under control.
+        mu1: Potential outcomes under treatment.
+
+    Returns:
+        Mean effect ``E[mu1 - mu0]`` as ``float``.
+    """
+    return torch.mean(mu1 - mu0).item()
+
+
+def gaussian_log_likelihood(
+    y: torch.Tensor, mean: torch.Tensor, var: torch.Tensor
+) -> float:
+    """Return the average Gaussian log-likelihood.
+
+    ``var`` must contain strictly positive values.
+
+    Args:
+        y: Observed outcomes.
+        mean: Predicted mean of the Gaussian distribution.
+        var: Predicted variance.
+
+    Returns:
+        Mean log probability of ``y`` under the Gaussian ``N(mean, var)``.
+    """
+    log_prob = -0.5 * (torch.log(2 * torch.pi * var) + (y - mean) ** 2 / var)
+    return torch.mean(log_prob).item()

--- a/src/causal_consistency_nn/serve.py
+++ b/src/causal_consistency_nn/serve.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+import torch
+
+
+def _device(model: torch.nn.Module) -> torch.device:
+    try:
+        return next(model.parameters()).device
+    except StopIteration:  # pragma: no cover
+        return torch.device("cpu")
+
+
+def predict_z(model: torch.nn.Module, x: torch.Tensor) -> torch.Tensor:
+    """Return the latent representation ``z`` for ``x``."""
+    device = _device(model)
+    model.eval()
+    with torch.no_grad():
+        out = model(x.to(device))
+        if isinstance(out, (tuple, list)):
+            z = out[0]
+        else:
+            z = out
+    return z.cpu()
+
+
+def counterfactual_z(
+    model: torch.nn.Module, x: torch.Tensor, t: torch.Tensor
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Return representation and counterfactual outcome for ``x``."""
+    device = _device(model)
+    model.eval()
+    with torch.no_grad():
+        out = model(x.to(device))
+        if isinstance(out, (tuple, list)) and len(out) >= 3:
+            z, mu0, mu1 = out[:3]
+        else:
+            raise ValueError("model must output (z, mu0, mu1)")
+        ycf = torch.where(t.to(device).bool(), mu0, mu1)
+    return z.cpu(), ycf.cpu()
+
+
+def impute_y(model: torch.nn.Module, x: torch.Tensor, t: torch.Tensor) -> torch.Tensor:
+    """Return outcome prediction for treatment ``t``."""
+    device = _device(model)
+    model.eval()
+    with torch.no_grad():
+        out = model(x.to(device))
+        if isinstance(out, (tuple, list)) and len(out) >= 3:
+            _, mu0, mu1 = out[:3]
+        else:
+            raise ValueError("model must output (z, mu0, mu1)")
+        ypred = torch.where(t.to(device).bool(), mu1, mu0)
+    return ypred.cpu()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,3 +5,6 @@ import sys
 ROOT_DIR = os.path.dirname(os.path.dirname(__file__))
 if ROOT_DIR not in sys.path:
     sys.path.insert(0, ROOT_DIR)
+SRC_DIR = os.path.join(ROOT_DIR, "src")
+if os.path.isdir(SRC_DIR) and SRC_DIR not in sys.path:
+    sys.path.insert(0, SRC_DIR)

--- a/tests/test_causal_consistency_nn.py
+++ b/tests/test_causal_consistency_nn.py
@@ -1,0 +1,55 @@
+import torch
+from torch.utils.data import DataLoader, TensorDataset
+
+from causal_consistency_nn.metrics import (
+    average_treatment_effect,
+    gaussian_log_likelihood,
+)
+from causal_consistency_nn.eval import evaluate
+from causal_consistency_nn.serve import predict_z, counterfactual_z, impute_y
+
+
+class DummyModel(torch.nn.Module):
+    def forward(self, x: torch.Tensor):
+        z = x[:, :1]
+        mu0 = z
+        mu1 = mu0 + 1.0
+        return z, mu0, mu1
+
+
+def test_metrics_and_eval():
+    torch.manual_seed(0)
+    x = torch.randn(20, 2)
+    t = torch.bernoulli(torch.full((20, 1), 0.5))
+    mu0 = x[:, :1]
+    mu1 = mu0 + 1.0
+    y = torch.where(t.bool(), mu1, mu0)
+    ds = TensorDataset(x, t, y)
+    loader = DataLoader(ds, batch_size=5)
+
+    ate_true = 1.0
+    assert abs(average_treatment_effect(mu0, mu1) - ate_true) < 1e-6
+    ll = gaussian_log_likelihood(y, y, torch.ones_like(y))
+    expected_ll = float(-0.5 * torch.log(torch.tensor(2 * torch.pi)))
+    assert abs(ll - expected_ll) < 1e-4
+
+    model = DummyModel()
+    metrics = evaluate(model, loader)
+    assert abs(metrics["ate"] - ate_true) < 1e-6
+    assert metrics["log_likelihood"] <= 0.0
+
+
+def test_serving_helpers():
+    model = DummyModel()
+    x = torch.randn(4, 2)
+    t = torch.tensor([[0], [1], [0], [1]], dtype=torch.float32)
+
+    z = predict_z(model, x)
+    assert z.shape == (4, 1)
+
+    z2, ycf = counterfactual_z(model, x, t)
+    assert z2.shape == (4, 1)
+    assert ycf.shape == (4, 1)
+
+    y_imp = impute_y(model, x, t)
+    assert y_imp.shape == (4, 1)


### PR DESCRIPTION
## Summary
- implement causal consistency utilities under `src/causal_consistency_nn`
- provide `average_treatment_effect` and `gaussian_log_likelihood`
- add evaluation helper and serving functions for inference
- expose new package in `pyproject.toml`
- update tests to include `src` on `PYTHONPATH`
- add integration tests for the new package
- document addition in `CHANGELOG`

## Testing
- `ruff check .`
- `black --check .`
- `pytest --cov=crosslearner --cov-report=xml -q`

------
https://chatgpt.com/codex/tasks/task_e_6852a09aab1083248ecbf4755e80e723