### PR TITLE
Implement evaluation and serving modules

### DIFF
--- a/src/causal_consistency_nn/__init__.py
+++ b/src/causal_consistency_nn/__init__.py
@@ -1,0 +1,26 @@
+"""Public API for ``causal_consistency_nn``."""
+
+from .config import SyntheticDataConfig
+from .data.synthetic import generate_synthetic, get_synthetic_dataloader
+from .metrics import (
+    ate,
+    att,
+    gaussian_log_likelihood,
+    bernoulli_log_likelihood,
+)
+from .eval import evaluate
+from .serve import predict_z, counterfactual_z, impute_y
+
+__all__ = [
+    "SyntheticDataConfig",
+    "generate_synthetic",
+    "get_synthetic_dataloader",
+    "ate",
+    "att",
+    "gaussian_log_likelihood",
+    "bernoulli_log_likelihood",
+    "evaluate",
+    "predict_z",
+    "counterfactual_z",
+    "impute_y",
+]

--- a/src/causal_consistency_nn/eval.py
+++ b/src/causal_consistency_nn/eval.py
@@ -1,0 +1,39 @@
+"""Dataset evaluation utilities."""
+
+from __future__ import annotations
+
+import torch
+from torch.utils.data import TensorDataset
+
+from .metrics import ate, gaussian_log_likelihood
+
+
+def evaluate(
+    mu0_pred: torch.Tensor,
+    mu1_pred: torch.Tensor,
+    dataset: TensorDataset,
+    *,
+    mu0_true: torch.Tensor | None = None,
+    mu1_true: torch.Tensor | None = None,
+    noise: float = 1.0,
+) -> dict[str, float]:
+    """Compute ATE and log-likelihood metrics for ``dataset``.
+
+    Args:
+        mu0_pred: Predicted outcome under control.
+        mu1_pred: Predicted outcome under treatment.
+        dataset: Dataset containing ``(X, T, Y)`` tensors.
+        mu0_true: Optional true control outcomes.
+        mu1_true: Optional true treated outcomes.
+        noise: Noise standard deviation assumed for the outcomes.
+    """
+
+    _, T, Y = dataset.tensors
+    ate_hat = ate(mu0_pred, mu1_pred)
+    pred_y = torch.where(T.bool(), mu1_pred, mu0_pred)
+    loglik = gaussian_log_likelihood(Y, pred_y, noise)
+
+    metrics = {"ate": ate_hat, "log_likelihood": loglik}
+    if mu0_true is not None and mu1_true is not None:
+        metrics["ate_error"] = ate_hat - ate(mu0_true, mu1_true)
+    return metrics

--- a/src/causal_consistency_nn/metrics.py
+++ b/src/causal_consistency_nn/metrics.py
@@ -1,0 +1,38 @@
+"""Utility metrics for causal inference models."""
+
+from __future__ import annotations
+
+import math
+import torch
+import torch.nn.functional as F
+
+
+def ate(mu0: torch.Tensor, mu1: torch.Tensor) -> float:
+    """Return the Average Treatment Effect from potential outcomes."""
+    return torch.mean(mu1 - mu0).item()
+
+
+def att(mu0: torch.Tensor, mu1: torch.Tensor, t: torch.Tensor) -> float:
+    """Return the Average Treatment Effect on the Treated."""
+    mask = t.view(-1).bool()
+    return torch.mean((mu1 - mu0).view(-1)[mask]).item()
+
+
+def gaussian_log_likelihood(
+    y: torch.Tensor, mean: torch.Tensor, sigma: float | torch.Tensor
+) -> float:
+    """Return the average Gaussian log-likelihood."""
+    if isinstance(sigma, (float, int)):
+        var = float(sigma) ** 2
+    else:
+        var = sigma**2
+    ll = -(
+        0.5 * torch.log(torch.tensor(2 * math.pi * var)) + (y - mean) ** 2 / (2 * var)
+    )
+    return ll.mean().item()
+
+
+def bernoulli_log_likelihood(target: torch.Tensor, logits: torch.Tensor) -> float:
+    """Return the average Bernoulli log-likelihood for ``logits``."""
+    ll = -F.binary_cross_entropy_with_logits(logits, target, reduction="mean")
+    return ll.item()

--- a/src/causal_consistency_nn/serve.py
+++ b/src/causal_consistency_nn/serve.py
@@ -1,0 +1,53 @@
+"""Model serving helpers."""
+
+from __future__ import annotations
+
+import torch
+from crosslearner.utils import model_device
+
+
+def _forward(model: torch.nn.Module, X: torch.Tensor) -> tuple[torch.Tensor, ...]:
+    device = model_device(model)
+    X = X.to(device)
+    model.eval()
+    with torch.no_grad():
+        out = model(X)
+    if not isinstance(out, tuple):
+        raise TypeError("model must return a tuple of tensors")
+    return out
+
+
+def predict_z(model: torch.nn.Module, X: torch.Tensor) -> torch.Tensor:
+    """Return latent representation ``z`` for ``X``."""
+    z, *_ = _forward(model, X)
+    return z.cpu()
+
+
+def counterfactual_z(
+    model: torch.nn.Module, X: torch.Tensor, t: torch.Tensor
+) -> torch.Tensor:
+    """Return counterfactual outcome predictions."""
+    _, mu0, mu1, _ = _forward(model, X)
+    return torch.where(t.to(mu0.device).bool(), mu0, mu1).cpu()
+
+
+def impute_y(
+    model: torch.nn.Module,
+    X: torch.Tensor,
+    t: torch.Tensor,
+    y: torch.Tensor,
+) -> torch.Tensor:
+    """Impute missing outcomes in ``y`` with model predictions."""
+    device = model_device(model)
+    X = X.to(device)
+    t = t.to(device)
+    mask = torch.isnan(y)
+    if not mask.any():
+        return y
+    model.eval()
+    with torch.no_grad():
+        _, mu0, mu1, _ = model(X)
+        pred = torch.where(t.bool(), mu1, mu0).cpu()
+    y = y.clone()
+    y[mask] = pred[mask]
+    return y

--- a/tests/test_ccnn_eval.py
+++ b/tests/test_ccnn_eval.py
@@ -1,0 +1,38 @@
+import torch
+
+from causal_consistency_nn.config import SyntheticDataConfig
+from causal_consistency_nn.data.synthetic import generate_synthetic
+from causal_consistency_nn.metrics import ate
+from causal_consistency_nn.eval import evaluate
+from causal_consistency_nn.serve import impute_y
+from crosslearner.models.acx import ACX
+
+
+def test_ate_function():
+    cfg = SyntheticDataConfig(n_samples=8, p=3, noise=0.1, seed=0)
+    dataset, (mu0, mu1) = generate_synthetic(cfg)
+    est = ate(mu0, mu1)
+    assert abs(est - (mu1 - mu0).mean().item()) < 1e-6
+
+
+def test_evaluate_synthetic():
+    cfg = SyntheticDataConfig(n_samples=20, p=3, noise=0.1, seed=0)
+    dataset, (mu0, mu1) = generate_synthetic(cfg)
+    good = evaluate(mu0, mu1, dataset, mu0_true=mu0, mu1_true=mu1, noise=cfg.noise)
+    zeros = torch.zeros_like(mu0)
+    bad = evaluate(zeros, zeros, dataset, mu0_true=mu0, mu1_true=mu1, noise=cfg.noise)
+    assert abs(good["ate_error"]) < 1e-6
+    assert good["log_likelihood"] > bad["log_likelihood"]
+
+
+def test_impute_y_replaces_missing():
+    cfg = SyntheticDataConfig(n_samples=10, p=3, noise=0.1, missing_y_prob=1.0, seed=0)
+    dataset, _ = generate_synthetic(cfg)
+    X, T, Y = dataset.tensors
+    model = ACX(p=cfg.p)
+    with torch.no_grad():
+        for p in model.parameters():
+            p.zero_()
+    out = impute_y(model, X, T, Y)
+    assert torch.isnan(out).sum() == 0
+    assert torch.allclose(out, torch.zeros_like(out))


### PR DESCRIPTION
## Summary
- add causal metrics: ATE, ATT, gaussian/bernoulli log-likelihood
- implement dataset evaluation helper
- expose serving helpers for inference
- create tests for new package

## Testing
- `ruff check .`
- `black --check .`
- `pytest --cov=crosslearner --cov-report=xml -q`

------
https://chatgpt.com/codex/tasks/task_e_6852a514672c83249075721bbcef3b4d