### PR TITLE
Add custom weight initialisation option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,3 +16,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added R1/R2 regularization and unrolled discriminator updates
 - Fixed `set_seed` to skip `torch.cuda.manual_seed_all` when CUDA is unavailable
 - Added synthetic data generation utilities with configurable noise and missing outcomes
+- Added configurable weight initialisation with ``init`` parameter

--- a/crosslearner/training/config.py
+++ b/crosslearner/training/config.py
@@ -27,6 +27,7 @@ class ModelConfig:
     disc_pack: int = (
         1  #: Number of samples concatenated for PacGAN-style discriminator.
     )
+    init: str | Callable[[nn.Linear], None] | None = None
 
 
 @dataclass

--- a/crosslearner/training/trainer.py
+++ b/crosslearner/training/trainer.py
@@ -49,6 +49,7 @@ class ACXTrainer:
             head_residual=model_cfg.head_residual,
             disc_residual=model_cfg.disc_residual,
             disc_pack=model_cfg.disc_pack,
+            init=model_cfg.init,
         ).to(self.device)
         if train_cfg.spectral_norm:
             apply_spectral_norm(self.model)
@@ -70,6 +71,7 @@ class ACXTrainer:
                 head_residual=model_cfg.head_residual,
                 disc_residual=model_cfg.disc_residual,
                 disc_pack=model_cfg.disc_pack,
+                init=model_cfg.init,
             ).to(self.device)
             if train_cfg.spectral_norm:
                 apply_spectral_norm(self.ema_model)

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -54,3 +54,15 @@ def test_acx_disc_pack():
     model = ACX(p=3, disc_pack=2)
     assert model.disc_pack == 2
     assert model.disc.net[0][0].in_features == 2 * (64 + 2)
+
+
+def test_acx_init_option():
+    def init(m):
+        nn.init.constant_(m.weight, 0.25)
+        if m.bias is not None:
+            nn.init.zeros_(m.bias)
+
+    model = ACX(p=3, init=init)
+    for module in model.mu0.modules():
+        if isinstance(module, nn.Linear):
+            assert torch.allclose(module.weight, torch.full_like(module.weight, 0.25))


### PR DESCRIPTION
## Summary
- allow selecting weight init scheme via `init` option
- initialise MLP weights using chosen scheme
- expose the option in `ModelConfig` and trainer
- document the new parameter in CHANGELOG
- test custom initialisers

## Testing
- `ruff check .`
- `black --check .`
- `pytest --cov=crosslearner --cov-report=xml -q`

------
https://chatgpt.com/codex/tasks/task_e_6853d43b2cf883248aa8443e96161629