### PR TITLE
Add optional batch norm layers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,3 +17,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed `set_seed` to skip `torch.cuda.manual_seed_all` when CUDA is unavailable
 - Added synthetic data generation utilities with configurable noise and missing outcomes
 - MLP and ACX are now TorchScript and ONNX exportable via `export_model`
+- Added optional batch normalization through `batch_norm` flag in `ModelConfig`

--- a/crosslearner/training/config.py
+++ b/crosslearner/training/config.py
@@ -27,6 +27,7 @@ class ModelConfig:
     disc_pack: int = (
         1  #: Number of samples concatenated for PacGAN-style discriminator.
     )
+    batch_norm: bool = False
 
 
 @dataclass

--- a/crosslearner/training/trainer.py
+++ b/crosslearner/training/trainer.py
@@ -49,6 +49,7 @@ class ACXTrainer:
             head_residual=model_cfg.head_residual,
             disc_residual=model_cfg.disc_residual,
             disc_pack=model_cfg.disc_pack,
+            batch_norm=model_cfg.batch_norm,
         ).to(self.device)
         if train_cfg.spectral_norm:
             apply_spectral_norm(self.model)
@@ -70,6 +71,7 @@ class ACXTrainer:
                 head_residual=model_cfg.head_residual,
                 disc_residual=model_cfg.disc_residual,
                 disc_pack=model_cfg.disc_pack,
+                batch_norm=model_cfg.batch_norm,
             ).to(self.device)
             if train_cfg.spectral_norm:
                 apply_spectral_norm(self.ema_model)

--- a/tests/test_training.py
+++ b/tests/test_training.py
@@ -319,6 +319,14 @@ def test_train_acx_dropout_options():
     assert any(isinstance(m, nn.Dropout) for m in model.disc.net.modules())
 
 
+def test_train_acx_batch_norm_option():
+    loader, _ = get_toy_dataloader(batch_size=4, n=8, p=4)
+    model_cfg = ModelConfig(p=4, batch_norm=True)
+    train_cfg = TrainingConfig(epochs=1, verbose=False)
+    model = train_acx(loader, model_cfg, train_cfg, device="cpu")
+    assert any(isinstance(m, nn.BatchNorm1d) for m in model.phi.net.modules())
+
+
 def test_alt_adv_losses():
     loader, _ = get_toy_dataloader(batch_size=4, n=8, p=4)
     model_cfg = ModelConfig(p=4)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -45,6 +45,12 @@ def test_mlp_forward_matches_sequential_without_residual():
     assert torch.allclose(y, y_seq)
 
 
+def test_mlp_batch_norm_layers():
+    mlp = MLP(4, 2, hidden=(3, 3), batch_norm=True)
+    bn_layers = [m for m in mlp.net.modules() if isinstance(m, nn.BatchNorm1d)]
+    assert len(bn_layers) == 2
+
+
 def test_set_seed_reproducibility():
     set_seed(123)
     r1 = random.random()


### PR DESCRIPTION
## Summary
- extend `MLP` with a `batch_norm` flag
- wire batch norm support through `ACX` and training config
- document the new option in the changelog
- test batch norm behaviour

## Testing
- `ruff check .`
- `black --check .`
- `pytest --cov=crosslearner --cov-report=xml -q`

------
https://chatgpt.com/codex/tasks/task_e_6853db910a0c832484df4c9c1532a90d