### PR TITLE
Add configurable weight initialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 - Initial creation of CHANGELOG
 - Added `crosslearner-benchmark` command comparing ACX to baseline models
+- Added configurable weight initialisation schemes for ACX MLPs
+- Fixed NaNs in DRLearner by clipping propensity scores
 - Added PacGAN-style discriminator packing via `disc_pack` configuration
 - Unified benchmark CLI and baseline comparison
 - Baseline MLPRegressors now train until convergence

--- a/crosslearner/models/baselines/drlearner.py
+++ b/crosslearner/models/baselines/drlearner.py
@@ -52,6 +52,7 @@ class DRLearner:
         else:
             self.model_e.fit(X, T)
             e_hat = self.model_e.predict_proba(X)[:, 1]
+        e_hat = np.clip(e_hat, 1e-3, 1 - 1e-3)
         mu0_hat = self.model_mu0.predict(X)
         mu1_hat = self.model_mu1.predict(X)
         tau_tilde = (

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -69,6 +69,18 @@ def test_apply_spectral_norm_applies_to_linear():
     assert hasattr(lin, "weight_u")
 
 
+def test_mlp_weight_init_zero_bias():
+    mlp = MLP(3, 2, hidden=(4,), weight_init="xavier_uniform")
+    for module in mlp.modules():
+        if isinstance(module, nn.Linear):
+            assert torch.allclose(module.bias, torch.zeros_like(module.bias))
+
+
+def test_mlp_weight_init_invalid():
+    with pytest.raises(ValueError):
+        MLP(3, 2, weight_init="invalid")
+
+
 def test_model_device_returns_correct_device():
     model = nn.Linear(1, 1)
     dev = model_device(model)


### PR DESCRIPTION
## Summary
- add `weight_init` argument throughout MLP and ACX
- initialise all linear layers according to Xavier or Kaiming schemes
- test weight initialisation helper
- clip extreme propensity scores in DRLearner
- document options in CHANGELOG

## Testing
- `ruff check .`
- `black --check .`
- `pytest --cov=crosslearner --cov-report=xml -q`


------
https://chatgpt.com/codex/tasks/task_e_6853d8f92a9883248b9b77a49ebe30f8