### PR TITLE
Add Monte Carlo dropout utility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,5 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   testing guide
 - Added optional contrastive loss via `contrastive_weight` for balanced
   covariates
+- Added Monte Carlo dropout utility `predict_tau_mc_dropout` for uncertainty
+  estimation
 - Added propensity head and doubly robust training objective via `delta_prop`
   and `lambda_dr` weights

--- a/README.md
+++ b/README.md
@@ -196,6 +196,19 @@ export_model(model, x, "acx.pt")
 export_model(model, x, "acx.onnx", onnx=True)
 ```
 
+## Uncertainty Estimation
+
+To quantify prediction confidence you can perform Monte Carlo dropout at
+inference time. The helper
+`predict_tau_mc_dropout` runs multiple forward passes with dropout enabled and
+returns the mean and standard deviation of the treatment effect:
+
+```python
+from crosslearner.evaluation import predict_tau_mc_dropout
+
+mean, std = predict_tau_mc_dropout(model, X, passes=50)
+```
+
 ## Documentation
 
 Hosted documentation is available at [https://mattsq.github.io/crosslearner/](https://mattsq.github.io/crosslearner/).

--- a/crosslearner/__init__.py
+++ b/crosslearner/__init__.py
@@ -4,6 +4,7 @@ from .datasets import get_toy_dataloader, get_complex_dataloader
 from .training.train_acx import train_acx
 from .training.history import EpochStats, History
 from .evaluation.evaluate import evaluate
+from .evaluation.uncertainty import predict_tau_mc_dropout
 from .experiments import ExperimentManager, cross_validate_acx
 from .utils import set_seed, default_device
 from .export import export_model
@@ -23,6 +24,7 @@ __all__ = [
     "EpochStats",
     "History",
     "evaluate",
+    "predict_tau_mc_dropout",
     "plot_losses",
     "scatter_tau",
     "plot_tau_distribution",

--- a/crosslearner/evaluation/__init__.py
+++ b/crosslearner/evaluation/__init__.py
@@ -9,6 +9,7 @@ from .metrics import (
     att_error,
     bootstrap_ci,
 )
+from .uncertainty import predict_tau_mc_dropout
 
 __all__ = [
     "evaluate",
@@ -19,5 +20,6 @@ __all__ = [
     "ate_error",
     "att_error",
     "bootstrap_ci",
+    "predict_tau_mc_dropout",
     "estimate_propensity",
 ]

--- a/crosslearner/evaluation/uncertainty.py
+++ b/crosslearner/evaluation/uncertainty.py
@@ -1,0 +1,36 @@
+"""Uncertainty estimation utilities."""
+
+from __future__ import annotations
+
+from typing import Tuple
+
+import torch
+
+from crosslearner.models.acx import ACX
+from crosslearner.utils import model_device
+
+
+@torch.no_grad()
+def predict_tau_mc_dropout(
+    model: ACX, X: torch.Tensor, *, passes: int = 100
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    """Return mean and standard deviation of MC dropout predictions.
+
+    The model is temporarily set to training mode so that dropout layers
+    remain active during the forward passes. Predictions are collected over
+    ``passes`` runs and aggregated to obtain an approximate posterior
+    mean and standard deviation for the treatment effect.
+    """
+
+    device = model_device(model)
+    X = X.to(device)
+    model.train()
+    samples = []
+    for _ in range(passes):
+        _, _, _, tau = model(X)
+        samples.append(tau)
+    stacked = torch.stack(samples)
+    mean = stacked.mean(dim=0)
+    std = stacked.std(dim=0)
+    model.eval()
+    return mean, std

--- a/docs/api/crosslearner.evaluation.rst
+++ b/docs/api/crosslearner.evaluation.rst
@@ -28,6 +28,14 @@ crosslearner.evaluation.propensity module
    :show-inheritance:
    :undoc-members:
 
+crosslearner.evaluation.uncertainty module
+------------------------------------------
+
+.. automodule:: crosslearner.evaluation.uncertainty
+   :members:
+   :show-inheritance:
+   :undoc-members:
+
 Module contents
 ---------------
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -16,6 +16,7 @@ the training procedure, hyperparameter sweeps and available modules.
    hyperparameter_sweeps
    usage_examples
    datasets
+   uncertainty
 
 
 .. toctree::

--- a/docs/uncertainty.rst
+++ b/docs/uncertainty.rst
@@ -1,0 +1,19 @@
+Uncertainty Estimation
+======================
+
+``crosslearner`` provides a simple Monte Carlo dropout utility to quantify
+prediction uncertainty. The function
+:func:`crosslearner.evaluation.predict_tau_mc_dropout` performs multiple forward
+passes with dropout enabled and returns the mean and standard deviation of the
+estimated treatment effects.
+
+Example usage::
+
+    from crosslearner.evaluation import predict_tau_mc_dropout
+
+    mean, std = predict_tau_mc_dropout(model, X, passes=50)
+    lower = mean - 1.96 * std
+    upper = mean + 1.96 * std
+
+This approximates a Bayesian posterior over the model weights and yields
+pointwise credible intervals for the CATE.

--- a/tests/test_uncertainty.py
+++ b/tests/test_uncertainty.py
@@ -1,0 +1,13 @@
+import torch
+
+from crosslearner.models.acx import ACX
+from crosslearner.evaluation.uncertainty import predict_tau_mc_dropout
+
+
+def test_mc_dropout_shapes_and_variance():
+    model = ACX(p=2, phi_dropout=0.5, head_dropout=0.5)
+    X = torch.randn(5, 2)
+    mean, std = predict_tau_mc_dropout(model, X, passes=20)
+    assert mean.shape == (5, 1)
+    assert std.shape == (5, 1)
+    assert torch.any(std > 0)


### PR DESCRIPTION
## Summary
- extend evaluation with `predict_tau_mc_dropout` for Bayesian-style uncertainty
- document uncertainty estimation and expose utility in the public API
- mention MC dropout in README and changelog
- include API docs for new module and a short tutorial page
- add tests covering the new helper

## Testing
- `ruff check crosslearner/evaluation/uncertainty.py crosslearner/__init__.py crosslearner/evaluation/__init__.py tests/test_uncertainty.py`
- `black crosslearner/evaluation/uncertainty.py crosslearner/__init__.py crosslearner/evaluation/__init__.py tests/test_uncertainty.py -q`
- `pytest --cov=crosslearner --cov-report=xml -q`

------
https://chatgpt.com/codex/tasks/task_e_68546c88ec7083249a6d48868e0f37a9