### PR TITLE
Improve docs for risk-based early stopping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,3 +36,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   gradient penalty strength based on discriminator loss
 - Added optional representation drift regularization via
   `rep_consistency_weight` and `rep_momentum`
+- Documented risk-based early stopping with `risk_data` option

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -17,6 +17,7 @@ the training procedure, hyperparameter sweeps and available modules.
    usage_examples
    datasets
    uncertainty
+   risk_early_stopping
 
 
 .. toctree::

--- a/docs/risk_early_stopping.rst
+++ b/docs/risk_early_stopping.rst
@@ -1,0 +1,53 @@
+Orthogonal Risk for Early Stopping
+=================================
+
+Training AC-X models often relies on validation PEHE computed from known potential outcomes.
+However, real datasets rarely provide counterfactual outcomes.  The ``risk_data`` option of
+:class:`~crosslearner.training.TrainingConfig` allows early stopping without ground truth by
+minimising an **orthogonal risk** estimated on a held-out triplet ``(X, T, Y)``.
+
+When ``risk_data`` is supplied the trainer first fits cross-fitted propensity and outcome
+models on the provided data using :func:`~crosslearner.training.nuisance.estimate_nuisances`.
+These nuisance estimates yield an orthogonal loss
+
+.. math::
+   R = \mathbb{E}\bigl[(Y - \mu_{T}(X) - (T - e(X))\,\tau(X))^2\bigr],
+
+where :math:`\tau(X)` is the predicted treatment effect and :math:`e(X)` and
+:math:`\mu_{T}(X)` are the learned nuisances.  Lower values indicate better causal
+estimates and the training loop stops if the risk fails to improve for
+``patience`` epochs.
+
+Example usage
+-------------
+
+.. code-block:: python
+
+   from crosslearner.datasets.toy import get_toy_dataloader
+   from crosslearner.training import ModelConfig, TrainingConfig
+   from crosslearner.training.train_acx import train_acx
+   import torch
+
+   loader, _ = get_toy_dataloader()
+   X = torch.cat([b[0] for b in loader])
+   T = torch.cat([b[1] for b in loader])
+   Y = torch.cat([b[2] for b in loader])
+
+   model_cfg = ModelConfig(p=10)
+   train_cfg = TrainingConfig(
+       epochs=50,
+       risk_data=(X, T, Y),
+       risk_folds=3,
+       patience=5,
+   )
+   model = train_acx(loader, model_cfg, train_cfg)
+
+Tips
+----
+
+* Increase ``risk_folds`` for more accurate cross-fitting on larger datasets.
+* ``nuisance_propensity_epochs`` and ``nuisance_outcome_epochs`` control the
+  training length of the nuisance models.
+* Combine ``risk_data`` with ``tensorboard_logdir`` to plot the risk over time.
+* If you have ground-truth potential outcomes prefer ``val_data`` to monitor
+  PEHE directly.


### PR DESCRIPTION
## Summary
- add page explaining how to use `risk_data` for early stopping
- link the new page from the docs index
- note the feature in the changelog

## Testing
- `ruff check .`
- `black --check .`
- `pytest --cov=crosslearner --cov-report=xml -q`

------
https://chatgpt.com/codex/tasks/task_e_68549baccf2883248120ef7c30876a66