### PR TITLE
Refactor unrolled discriminator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added hinge and least-squares GAN losses via `adv_loss` option
 - Added exponential moving average (`ema_decay`) for generator parameters
 - Added R1/R2 regularization and unrolled discriminator updates
+- Refactored unrolled discriminator logic to use stateless functional calls
 - Fixed `set_seed` to skip `torch.cuda.manual_seed_all` when CUDA is unavailable
 - Added synthetic data generation utilities with configurable noise and missing outcomes
 - MLP and ACX are now TorchScript and ONNX exportable via `export_model`


### PR DESCRIPTION
## Summary
- avoid deepcopy in `_unrolled_logits`
- use functional calls for the discriminator during unrolled updates
- document refactor in CHANGELOG

## Testing
- `ruff check .`
- `black --check .`
- `pytest --cov=crosslearner --cov-report=xml -q`


------
https://chatgpt.com/codex/tasks/task_e_6854db3a7a5883248d01eb09c3b20ddd