### PR TITLE
Remove retain_graph in gradient penalty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,4 +44,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   how predicted treatment effects change with a single feature
 - Replaced pairwise distance computation in `_mmd_rbf` with `torch.cdist` and
   added regression test
+- Removed `retain_graph=True` from gradient penalty computation
 

--- a/crosslearner/training/trainer.py
+++ b/crosslearner/training/trainer.py
@@ -463,7 +463,6 @@ class ACXTrainer:
                                 inputs=interpolates,
                                 grad_outputs=torch.ones_like(interp_logits),
                                 create_graph=True,
-                                retain_graph=True,
                                 only_inputs=True,
                             )[0]
                             gp = (


### PR DESCRIPTION
## Summary
- simplify gradient penalty by removing retain_graph
- document the change in the changelog

## Testing
- `ruff check .`
- `black --check .`
- `pytest --cov=crosslearner --cov-report=xml -q`


------
https://chatgpt.com/codex/tasks/task_e_6854e0866c44832490b0450e34539bf4