### PR TITLE
Optimize zero_grad calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,4 +46,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   added regression test
 - Removed `retain_graph=True` from gradient penalty computation
 - Vectorised R1/R2 gradient penalty computation
+- Optimized optimizer resets using `zero_grad(set_to_none=True)` in `ACXTrainer`
 

--- a/crosslearner/training/trainer.py
+++ b/crosslearner/training/trainer.py
@@ -414,7 +414,7 @@ class ACXTrainer:
 
             if cfg.warm_start > 0 and epoch < cfg.warm_start:
                 loss_y = mse(torch.where(Tb.bool(), m1, m0), Yb)
-                opt_g.zero_grad()
+                opt_g.zero_grad(set_to_none=True)
                 loss_y.backward()
                 if cfg.grad_clip:
                     nn.utils.clip_grad_norm_(model.parameters(), cfg.grad_clip)
@@ -534,7 +534,7 @@ class ACXTrainer:
                         loss_d = loss_d + 0.5 * cfg.r2_gamma * penalty
 
                     if not freeze_d:
-                        opt_d.zero_grad()
+                        opt_d.zero_grad(set_to_none=True)
                         loss_d.backward()
                         opt_d.step()
                         if cfg.weight_clip is not None:
@@ -644,7 +644,7 @@ class ACXTrainer:
                 loss_grl = bce(t_logits, Tb)
                 loss_g += loss_grl
 
-            opt_g.zero_grad()
+            opt_g.zero_grad(set_to_none=True)
             loss_g.backward()
             if cfg.grad_clip:
                 nn.utils.clip_grad_norm_(model.parameters(), cfg.grad_clip)


### PR DESCRIPTION
## Summary
- set `set_to_none=True` in `ACXTrainer.zero_grad` calls for improved performance
- document optimizer reset optimization in the changelog

## Testing
- `ruff check .`
- `black --check .`
- `pytest --cov=crosslearner --cov-report=xml -q`


------
https://chatgpt.com/codex/tasks/task_e_6854ed5620888324ae2dc7b7bb13ab02