### PR TITLE
Optimize negative sampling logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,4 +47,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Removed `retain_graph=True` from gradient penalty computation
 - Vectorised R1/R2 gradient penalty computation
 - Optimized optimizer resets using `zero_grad(set_to_none=True)` in `ACXTrainer`
+- Replaced pairwise-mask logic in `_sample_negatives` with index lists for each
+  treatment group
 


### PR DESCRIPTION
## Summary
- replace pairwise mask in `_sample_negatives` with index lists
- update changelog

## Testing
- `ruff check .`
- `black --check .`
- `pytest --cov=crosslearner --cov-report=xml -q`


------
https://chatgpt.com/codex/tasks/task_e_6854f26691148324b992d049ad41f64d