### PR TITLE
Optimize MMD distance matrix calculation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,4 +51,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   treatment group
 - Cached a zero tensor per epoch and replaced redundant `torch.tensor(0.0)`
   constructions
+- Reused a single `torch.cdist` to compute all pairwise distances in `_mmd_rbf`
 

--- a/crosslearner/training/trainer.py
+++ b/crosslearner/training/trainer.py
@@ -24,12 +24,13 @@ def _mmd_rbf(x: torch.Tensor, y: torch.Tensor, sigma: float = 1.0) -> torch.Tens
 
     if x.numel() == 0 or y.numel() == 0:
         return torch.tensor(0.0, device=x.device)
-    dist_xx = torch.cdist(x, x).pow(2)
-    dist_yy = torch.cdist(y, y).pow(2)
-    dist_xy = torch.cdist(x, y).pow(2)
-    k_xx = torch.exp(-dist_xx / (2 * sigma**2))
-    k_yy = torch.exp(-dist_yy / (2 * sigma**2))
-    k_xy = torch.exp(-dist_xy / (2 * sigma**2))
+    xy = torch.cat([x, y])
+    dist = torch.cdist(xy, xy).pow(2)
+    k = torch.exp(-dist / (2 * sigma**2))
+    n_x = x.size(0)
+    k_xx = k[:n_x, :n_x]
+    k_yy = k[n_x:, n_x:]
+    k_xy = k[:n_x, n_x:]
     return k_xx.mean() + k_yy.mean() - 2 * k_xy.mean()
 
 

--- a/tests/test_mmd.py
+++ b/tests/test_mmd.py
@@ -24,6 +24,16 @@ def test_mmd_rbf_matches_manual():
     assert torch.allclose(actual, expected, atol=1e-6)
 
 
+def test_mmd_rbf_non_default_sigma():
+    torch.manual_seed(1)
+    x = torch.randn(8, 2)
+    y = torch.randn(7, 2)
+    sigma = 2.5
+    expected = _mmd_rbf_manual(x, y, sigma)
+    actual = _mmd_rbf(x, y, sigma)
+    assert torch.allclose(actual, expected, atol=1e-6)
+
+
 def test_mmd_rbf_empty_inputs():
     x = torch.empty(0, 3)
     y = torch.randn(4, 3)


### PR DESCRIPTION
## Summary
- compute all pairwise distances in `_mmd_rbf` in one `torch.cdist` call
- validate behaviour with a new non-default sigma test
- note the improvement in the changelog

## Testing
- `ruff check .`
- `black --check .`
- `pytest --cov=crosslearner --cov-report=xml -q`

------
https://chatgpt.com/codex/tasks/task_e_6854fed819fc83248665ec6eb545fd9a