### PR TITLE
Use torch.func.functional_call in unrolled discriminator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added exponential moving average (`ema_decay`) for generator parameters
 - Added R1/R2 regularization and unrolled discriminator updates
 - Refactored unrolled discriminator logic to use stateless functional calls
+- Refined unrolled discriminator updates to use torch.func.functional_call and
+  in-place parameter updates
 - Fixed `set_seed` to skip `torch.cuda.manual_seed_all` when CUDA is unavailable
 - Added synthetic data generation utilities with configurable noise and missing outcomes
 - MLP and ACX are now TorchScript and ONNX exportable via `export_model`


### PR DESCRIPTION
## Summary
- use `torch.func.functional_call` for unrolled discriminator steps
- update unrolled parameter updates to detach in-place
- document the change in `CHANGELOG.md`

## Testing
- `ruff check .`
- `black --check .`
- `pytest --cov=crosslearner --cov-report=xml -q`

------
https://chatgpt.com/codex/tasks/task_e_685502daa34083248bdd40db66f86274