### PR TITLE
Document doubly robust training options

### DIFF
--- a/crosslearner/training/config.py
+++ b/crosslearner/training/config.py
@@ -81,8 +81,8 @@ class TrainingConfig:
     contrastive_weight: float = 0.0
     contrastive_margin: float = 1.0
     contrastive_noise: float = 0.0
-    delta_prop: float = 0.0
-    lambda_dr: float = 0.0
+    delta_prop: float = 0.0  #: Weight for the propensity head cross-entropy loss.
+    lambda_dr: float = 0.0  #: Weight for the doubly robust loss term.
     noise_std: float = 0.0
     noise_consistency_weight: float = 0.0
     rep_consistency_weight: float = 0.0

--- a/docs/doubly_robust.rst
+++ b/docs/doubly_robust.rst
@@ -1,0 +1,45 @@
+Doubly Robust Objective and Propensity Head
+==========================================
+
+``crosslearner`` supports an optional propensity head and a doubly robust
+objective. Both are controlled through
+:class:`~crosslearner.training.TrainingConfig`.
+
+Motivation
+----------
+
+The propensity head predicts treatment assignment from the learned
+representation. Including a binary cross-entropy term encourages the
+network to model treatment probabilities alongside the potential outcomes,
+which can stabilise adversarial training. The doubly robust loss further
+reduces bias by combining regression and inverse propensity weighting. A
+learned ``epsilon`` parameter adjusts the contribution of the weighted
+pseudo-outcome.
+
+Usage
+-----
+
+Enable these components by setting ``delta_prop`` and ``lambda_dr`` when
+constructing ``TrainingConfig``::
+
+   cfg = TrainingConfig(
+       epochs=30,
+       delta_prop=1.0,
+       lambda_dr=0.1,
+   )
+   model = train_acx(loader, ModelConfig(p=10), cfg)
+
+During training the model minimises ``delta_prop`` times the binary
+cross-entropy between predicted propensity scores and observed treatment.
+The doubly robust penalty weighted by ``lambda_dr`` compares the outcome to a
+bias-corrected estimate using the propensity head and ``epsilon``.
+
+When to use it
+--------------
+
+Use ``delta_prop`` when you want the network to explicitly model the
+treatment assignment mechanism or when the discriminator struggles due to
+covariate imbalance. ``lambda_dr`` is most helpful on smaller datasets or
+in the presence of confounding, as it blends outcome regression with
+importance weighting. Typical values are between ``0.5`` and ``2`` for
+``delta_prop`` and around ``0.1`` for ``lambda_dr``.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -17,6 +17,7 @@ the training procedure, hyperparameter sweeps and available modules.
    usage_examples
    gradient_reversal
    feature_matching
+   doubly_robust
    datasets
    uncertainty
    risk_early_stopping


### PR DESCRIPTION
## Summary
- document propensity head and doubly robust loss
- show how to enable these hyperparameters
- explain when to use the options

## Testing
- `ruff check .`
- `black --check .`
- `pytest --cov=crosslearner --cov-report=xml -q`


------
https://chatgpt.com/codex/tasks/task_e_68551038da4483249e73e745de5fdb01