### PR TITLE
Add instance noise documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,4 +57,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Reused a single `torch.cdist` to compute all pairwise distances in `_mmd_rbf`
 - Switched `_mmd_rbf` to an unbiased estimator using the kernel trick and added
   a regression test comparing to the previous implementation
+- Documented the ``instance_noise`` training option with motivation and usage details
 

--- a/crosslearner/training/config.py
+++ b/crosslearner/training/config.py
@@ -58,7 +58,10 @@ class TrainingConfig:
     spectral_norm: bool = False
     feature_matching: bool = False
     label_smoothing: bool = False
-    instance_noise: bool = False
+    instance_noise: bool = (
+        False
+        #: Add decaying Gaussian noise to discriminator targets to regularise early training.
+    )
     gradient_reversal: bool = False
     ttur: bool = False
     disc_steps: int = 1

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -18,6 +18,7 @@ the training procedure, hyperparameter sweeps and available modules.
    gradient_reversal
    feature_matching
    spectral_norm
+   instance_noise
    unrolled_discriminator
    doubly_robust
    datasets

--- a/docs/instance_noise.rst
+++ b/docs/instance_noise.rst
@@ -1,0 +1,43 @@
+Instance Noise for Robust Discriminator
+======================================
+
+The ``instance_noise`` option injects Gaussian noise into the discriminator's
+input targets early in training. Both the real outcomes ``Y`` and counterfactual
+estimates ``Ycf`` receive noise whose standard deviation decays linearly from
+``0.2`` to ``0`` over the course of ``epochs``. This prevents the
+discriminator from overfitting to exact outcome values and gives the generator
+a smoother optimisation landscape.
+
+Motivation
+----------
+
+When the discriminator can perfectly separate real from fake samples it may
+drastically reduce the generator's gradient signal. Adding small noise to the
+outcomes effectively blurs the decision boundary and regularises the
+discriminator. This is particularly helpful when datasets are small or noisy,
+where the discriminator might otherwise memorise the training data.
+
+Usage
+-----
+
+Enable instance noise by setting ``instance_noise=True`` in
+:class:`~crosslearner.training.TrainingConfig`::
+
+   cfg = TrainingConfig(
+       epochs=30,
+       instance_noise=True,
+   )
+   model = train_acx(loader, ModelConfig(p=10), cfg)
+
+During each discriminator update a noise term is added to the observed outcome
+and the counterfactual prediction. The noise magnitude starts at ``0.2`` and
+decays linearly to ``0`` by the final epoch.
+
+When to use it
+--------------
+
+Use ``instance_noise`` when training is unstable or the discriminator quickly
+achieves near-perfect accuracy. It works well together with other
+regularisation techniques such as feature matching or gradient reversal. On
+very large datasets or when discriminator overfitting is not an issue, the
+option can be left disabled.


### PR DESCRIPTION
## Summary
- document `instance_noise` training option in a new docs page
- reference the page from the docs index
- briefly describe the option in the config dataclass
- note the change in the changelog

## Testing
- `ruff check .`
- `black --check .`
- `pytest --cov=crosslearner --cov-report=xml -q`


------
https://chatgpt.com/codex/tasks/task_e_6855d86b8a8c83249b89ed2ac85abe7b