### PR TITLE
Add discriminator augmentation docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,4 +58,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Switched `_mmd_rbf` to an unbiased estimator using the kernel trick and added
   a regression test comparing to the previous implementation
 - Documented the ``instance_noise`` training option with motivation and usage details
+- Documented optional discriminator feature augmentation via ``disc_aug_prob`` and ``disc_aug_noise``
 

--- a/docs/discriminator_augmentation.rst
+++ b/docs/discriminator_augmentation.rst
@@ -1,0 +1,48 @@
+Discriminator Feature Augmentation
+=================================
+
+The ``disc_aug_prob`` and ``disc_aug_noise`` options provide simple data
+augmentation for the discriminator. During each discriminator update the
+encoded representation ``h_b`` is optionally corrupted before being fed to the
+adversary. ``disc_aug_prob`` applies dropout with the given probability and
+``disc_aug_noise`` adds Gaussian noise with the specified standard deviation.
+This augmentation is applied equally to real and fake samples so the
+discriminator must remain robust to these perturbations.
+
+Motivation
+----------
+
+GAN discriminators often learn sharp decision boundaries that quickly
+separate the generator's outputs from real data. When this happens the
+generator receives vanishing gradients and training stalls. By randomly
+dropping features or adding jitter we force the discriminator to rely on
+broader patterns rather than exact activations, preventing early
+overfitting. These simple perturbations can stabilise adversarial training,
+especially on small datasets.
+
+Usage
+-----
+
+Enable the augmentation through :class:`~crosslearner.training.TrainingConfig`
+by setting either ``disc_aug_prob`` or ``disc_aug_noise`` (or both)::
+
+   cfg = TrainingConfig(
+       epochs=30,
+       disc_aug_prob=0.2,
+       disc_aug_noise=0.05,
+   )
+   model = train_acx(loader, ModelConfig(p=10), cfg)
+
+With the above configuration each discriminator step will use dropout with
+probability ``0.2`` on the representation passed to the discriminator and
+add Gaussian noise with standard deviation ``0.05``.
+
+When to use it
+--------------
+
+``disc_aug_prob`` and ``disc_aug_noise`` are most helpful when the
+discriminator easily distinguishes real from fake samples, leading to
+training instability. They act as lightweight regularisers and pair well with
+other stabilisation techniques such as feature matching or gradient
+reversal. On very large datasets or when the discriminator already trains
+slowly, these options can usually be left at ``0``.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -19,6 +19,7 @@ the training procedure, hyperparameter sweeps and available modules.
    feature_matching
    spectral_norm
    instance_noise
+   discriminator_augmentation
    unrolled_discriminator
    doubly_robust
    datasets


### PR DESCRIPTION
## Summary
- document discriminator feature augmentation with `disc_aug_prob` and `disc_aug_noise`
- include page in Sphinx index
- mention new documentation in `CHANGELOG`

## Testing
- `ruff check .`
- `black --check .`
- `pytest --cov=crosslearner --cov-report=xml -q`

------
https://chatgpt.com/codex/tasks/task_e_6855e1ea6034832486c3411b43b39e1a