### PR TITLE
Add docs for MMD regularization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,4 +60,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Documented the ``instance_noise`` training option with motivation and usage details
 - Documented optional discriminator feature augmentation via ``disc_aug_prob`` and ``disc_aug_noise``
 - Documented representation disentanglement with ``adv_t_weight`` and ``adv_y_weight``
+- Documented optional MMD regularisation via ``mmd_weight`` and ``mmd_sigma``
 

--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ cross-validated $\sqrt{\mathrm{PEHE}}$ across the built-in synthetic datasets:
 - `crosslearner/evaluation/` – metrics such as PEHE.
 - `crosslearner/configs/` – YAML configs with hyper‑parameters.
 
-The training code exposes options for Wasserstein loss with gradient penalty, hinge and least‑squares objectives, spectral normalisation, feature matching, exponential moving average, instance noise, PacGAN-style discriminator packing, gradient reversal and two‑time‑scale update rule (TTUR). Early stopping on validation $\sqrt{\mathrm{PEHE}}$ is also provided. Dropout can be configured separately for the representation, head and discriminator networks.
+The training code exposes options for Wasserstein loss with gradient penalty, hinge and least‑squares objectives, spectral normalisation, feature matching, MMD regularisation, exponential moving average, instance noise, PacGAN-style discriminator packing, gradient reversal and two‑time‑scale update rule (TTUR). Early stopping on validation $\sqrt{\mathrm{PEHE}}$ is also provided. Dropout can be configured separately for the representation, head and discriminator networks.
 
 Use the config file as a starting point for your own experiments on IHDP, ACIC or other datasets.
 

--- a/crosslearner/models/baselines/drlearner.py
+++ b/crosslearner/models/baselines/drlearner.py
@@ -52,6 +52,11 @@ class DRLearner:
         else:
             self.model_e.fit(X, T)
             e_hat = self.model_e.predict_proba(X)[:, 1]
+
+        # guard against extreme propensities which would otherwise create
+        # NaNs in the doubly robust pseudo-outcomes
+        eps = 1e-3
+        e_hat = np.clip(e_hat, eps, 1 - eps)
         mu0_hat = self.model_mu0.predict(X)
         mu1_hat = self.model_mu1.predict(X)
         tau_tilde = (

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -20,6 +20,7 @@ the training procedure, hyperparameter sweeps and available modules.
    spectral_norm
    instance_noise
    contrastive_loss
+   mmd_regularization
    representation_disentanglement
    discriminator_augmentation
    unrolled_discriminator

--- a/docs/mmd_regularization.rst
+++ b/docs/mmd_regularization.rst
@@ -1,0 +1,46 @@
+MMD Regularization for Balanced Representations
+===============================================
+
+The ``mmd_weight`` and ``mmd_sigma`` options introduce a kernel-based
+regularisation term. During each generator update the encoder outputs for
+treated and control units are compared using the **maximum mean discrepancy**
+(MMD) with a radial basis function (RBF) kernel. The squared MMD is multiplied
+by ``mmd_weight`` and added to the generator loss.
+
+Motivation
+----------
+
+Adversarial consistency alone may not fully align the representation
+across treatment groups. If the discriminator easily separates real and
+counterfactual outcomes, the generator can still learn distinct feature
+distributions for treated and control samples. The MMD penalty explicitly
+drives the mean embeddings of both groups together, encouraging an
+invariant representation that improves effect estimation on imbalanced
+datasets.
+
+Usage
+-----
+
+Activate the penalty by setting ``mmd_weight`` to a positive value in
+:class:`~crosslearner.training.TrainingConfig`::
+
+   cfg = TrainingConfig(
+       epochs=30,
+       mmd_weight=0.5,
+       mmd_sigma=2.0,
+   )
+   model = train_acx(loader, ModelConfig(p=10), cfg)
+
+``mmd_sigma`` controls the bandwidth of the RBF kernel. Start with a
+value similar to the standard deviation of the encoder output (often
+between ``1`` and ``3``).
+
+When to use it
+--------------
+
+Use MMD regularisation when treatment groups have markedly different
+covariate distributions or when the discriminator quickly overpowers the
+generator. It pairs well with feature matching and discriminator
+augmentation. Large ``mmd_weight`` values can slow convergence, so begin
+with a small weight such as ``0.1`` and increase only if the
+representations remain divergent.


### PR DESCRIPTION
## Summary
- document MMD regularisation via `mmd_weight` and `mmd_sigma`
- list the new feature in the index and README
- note the change in `CHANGELOG.md`
- clamp extreme propensities in DRLearner to avoid NaN pseudo-outcomes

## Testing
- `ruff check .`
- `black --check .`
- `pytest --cov=crosslearner --cov-report=xml -q`

------
https://chatgpt.com/codex/tasks/task_e_6855f444d1bc83248d72edfd13519e2f