### PR TITLE
Document tensorboard_logdir

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,4 +62,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Documented optional discriminator feature augmentation via ``disc_aug_prob`` and ``disc_aug_noise``
 - Documented representation disentanglement with ``adv_t_weight`` and ``adv_y_weight``
 - Documented optional MMD regularisation via ``mmd_weight`` and ``mmd_sigma``
+- Documented TensorBoard logging via ``tensorboard_logdir`` option
 

--- a/crosslearner/training/config.py
+++ b/crosslearner/training/config.py
@@ -100,7 +100,10 @@ class TrainingConfig:
         #: Weight for predicting the observed outcome from the confounder and
         #: instrument representations when ``disentangle=True``.
     )
-    tensorboard_logdir: Optional[str] = None
+    tensorboard_logdir: Optional[str] = (
+        None
+        #: Directory in which to write TensorBoard event files during training.
+    )
     weight_clip: Optional[float] = None
     val_data: Optional[Tuple[torch.Tensor, torch.Tensor, torch.Tensor]] = None
     risk_data: Optional[Tuple[torch.Tensor, torch.Tensor, torch.Tensor]] = None

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -28,6 +28,7 @@ the training procedure, hyperparameter sweeps and available modules.
    datasets
    uncertainty
    risk_early_stopping
+   tensorboard_logging
 
 
 .. toctree::

--- a/docs/tensorboard_logging.rst
+++ b/docs/tensorboard_logging.rst
@@ -1,0 +1,40 @@
+Monitoring Training with TensorBoard
+===================================
+
+The ``tensorboard_logdir`` option of :class:`~crosslearner.training.TrainingConfig`
+enables detailed logging of the training progress. When set to a directory path
+an instance of :class:`torch.utils.tensorboard.SummaryWriter` is created and
+standard metrics are written as event files. This includes generator and
+adversary losses as well as the validation PEHE or orthogonal risk if either
+``val_data`` or ``risk_data`` are provided.
+
+Motivation
+----------
+
+Visualising loss curves helps diagnose convergence issues and compare different
+settings. TensorBoard provides an interactive dashboard that lets you inspect
+how metrics evolve over time. This is useful when tuning hyperparameters or
+running longer experiments where printing every epoch would clutter the output.
+
+Usage
+-----
+
+Pass a directory to ``tensorboard_logdir`` in the training configuration::
+
+   cfg = TrainingConfig(
+       epochs=30,
+       tensorboard_logdir="runs/experiment1",
+   )
+   model = train_acx(loader, ModelConfig(p=10), cfg)
+
+After training launch TensorBoard to view the logs::
+
+   tensorboard --logdir runs/experiment1
+
+When to use it
+--------------
+
+Enable ``tensorboard_logdir`` whenever you want a graphical overview of the
+training process. It is especially helpful during development to spot unstable
+adversarial dynamics or overfitting. For quick tests you can keep it ``None`` to
+avoid writing additional files.


### PR DESCRIPTION
## Summary
- document `tensorboard_logdir` option in training config
- add docs page on TensorBoard logging

## Testing
- `ruff check .`
- `black --check .`
- `pytest --cov=crosslearner --cov-report=xml -q`


------
https://chatgpt.com/codex/tasks/task_e_6855fc2e021083249cb256d61c4388fe