### PR TITLE
Improve docs for consistency regularization

### DIFF
--- a/docs/consistency_regularization.rst
+++ b/docs/consistency_regularization.rst
@@ -1,0 +1,63 @@
+Consistency Regularization
+==========================
+
+Several optional hyperparameters encourage stable representations and robust predictions
+by penalising inconsistency in the encoder and outputs.
+These settings are all part of :class:`~crosslearner.training.TrainingConfig`.
+
+Noise Consistency
+-----------------
+
+``noise_std`` controls the standard deviation of Gaussian noise added to the
+input features during training.  When ``noise_consistency_weight`` is positive,
+the model is evaluated on both the clean and noisy inputs and their predictions
+are compared with a mean squared error penalty.  The additional loss
+``noise_consistency_weight`` \* ``MSE(f(X), f(X+\epsilon))`` encourages the
+potential outcome and treatment effect heads to be invariant to small
+perturbations.  This acts as a lightweight data augmentation that can improve
+robustness.
+
+Example usage::
+
+   cfg = TrainingConfig(
+       epochs=30,
+       noise_std=0.1,
+       noise_consistency_weight=1.0,
+   )
+   model = train_acx(loader, ModelConfig(p=10), cfg)
+
+Representation Drift
+--------------------
+
+``rep_consistency_weight`` introduces a penalty on changes in the encoder's
+representation statistics across epochs.  For each treatment group the trainer
+tracks an exponential moving average of the mean and variance of the encoded
+features.  ``rep_momentum`` sets the decay rate for this moving average
+(default ``0.99``).  During training the current batch statistics are compared
+to the stored averages and their squared difference is scaled by
+``rep_consistency_weight``.
+
+This regularisation discourages large shifts in the latent space, which can
+otherwise destabilise adversarial training.  It is especially helpful when the
+encoder oscillates or collapses as the discriminator improves.
+
+Example usage::
+
+   cfg = TrainingConfig(
+       epochs=30,
+       rep_consistency_weight=0.5,
+       rep_momentum=0.95,
+   )
+   model = train_acx(loader, ModelConfig(p=10), cfg)
+
+When to use it
+--------------
+
+Enable these penalties when training becomes unstable or when small input
+perturbations lead to noticeably different predictions.  Start with small
+weights (around ``0.5`` for ``rep_consistency_weight`` and ``0.1`` to ``1.0``
+for ``noise_consistency_weight``) and only increase them if the model still
+exhibits large variance between epochs.  On very large datasets or when
+adversarial training is already stable, these options can be left at their
+default value of ``0``.
+

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -23,6 +23,7 @@ the training procedure, hyperparameter sweeps and available modules.
    contrastive_loss
    mmd_regularization
    representation_disentanglement
+   consistency_regularization
    discriminator_augmentation
    unrolled_discriminator
    doubly_robust


### PR DESCRIPTION
## Summary
- add a new page explaining `noise_std`, `noise_consistency_weight`, `rep_consistency_weight` and `rep_momentum`
- include the page in the main documentation index

## Testing
- `ruff check .`
- `black --check .`
- `pytest --cov=crosslearner --cov-report=xml -q`

------
https://chatgpt.com/codex/tasks/task_e_685606c6b9b08324bad908f02fc41b0b