### PR TITLE
Improve warm_start documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,4 +63,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Documented representation disentanglement with ``adv_t_weight`` and ``adv_y_weight``
 - Documented optional MMD regularisation via ``mmd_weight`` and ``mmd_sigma``
 - Documented TensorBoard logging via ``tensorboard_logdir`` option
+- Documented ``warm_start`` option for pretraining the generator
 

--- a/crosslearner/training/config.py
+++ b/crosslearner/training/config.py
@@ -51,7 +51,12 @@ class TrainingConfig:
     sched_g_kwargs: dict = field(default_factory=dict)
     sched_d_kwargs: dict = field(default_factory=dict)
     grad_clip: float = 2.0
-    warm_start: int = 0
+    warm_start: int = (
+        0
+        #: Number of initial epochs using only the outcome loss before
+        #: adversarial objectives kick in.  Setting this to ``>0`` can
+        #: stabilise training on small or noisy datasets.
+    )
     use_wgan_gp: bool = False
     adv_loss: str = "bce"
     ema_decay: Optional[float] = None

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -26,6 +26,7 @@ the training procedure, hyperparameter sweeps and available modules.
    consistency_regularization
    discriminator_augmentation
    unrolled_discriminator
+   warm_start
    doubly_robust
    datasets
    uncertainty

--- a/docs/warm_start.rst
+++ b/docs/warm_start.rst
@@ -1,0 +1,42 @@
+Warm Start for Stable Optimisation
+=================================
+
+The ``warm_start`` option of :class:`~crosslearner.training.TrainingConfig`
+pretrains the generator before adversarial updates begin.  When set to a
+positive integer only the outcome heads are trained for that many epochs
+using the mean squared error on the observed outcomes.  No adversarial or
+consistency terms are applied during this phase.
+
+Motivation
+----------
+
+GAN objectives can be brittle at the start of training when both the
+generator and discriminator are poorly calibrated.  Jumping straight into
+the adversarial game might lead to exploding or vanishing gradients.  By
+warming up with a few epochs of simple outcome prediction the generator can
+learn a reasonable initialisation which stabilises the subsequent
+adversarial training.  This is particularly helpful on small or noisy
+datasets where the discriminator tends to overpower the generator early on.
+
+Usage
+-----
+
+Pass the desired number of warm-up epochs to ``warm_start``::
+
+   cfg = TrainingConfig(
+       epochs=30,
+       warm_start=5,
+   )
+   model = train_acx(loader, ModelConfig(p=10), cfg)
+
+During the first five epochs only the outcome reconstruction loss is
+optimised.  Starting from epoch six the full objective---including
+consistency and adversarial losses---is used.
+
+When to use it
+--------------
+
+Enable a warm start when training becomes unstable right from the start or
+when the discriminator loss decreases too quickly.  A short warm-up of one
+or two epochs often suffices.  Set ``warm_start`` to ``0`` (the default) to
+skip this phase if training is already stable.


### PR DESCRIPTION
## Summary
- explain how to use `warm_start` in TrainingConfig
- add detailed documentation page for warm start
- link warm_start docs from the index
- mention warm_start docs in CHANGELOG

## Testing
- `ruff check .`
- `black --check .`
- `pytest --cov=crosslearner --cov-report=xml -q`


------
https://chatgpt.com/codex/tasks/task_e_68560b0918e08324a0b3aae2cb2ff7c3