### PR TITLE
Improve TTUR documentation

### DIFF
--- a/crosslearner/training/config.py
+++ b/crosslearner/training/config.py
@@ -68,7 +68,11 @@ class TrainingConfig:
         #: Add decaying Gaussian noise to discriminator targets to regularise early training.
     )
     gradient_reversal: bool = False
-    ttur: bool = False
+    ttur: bool = (
+        False
+        #: Freeze discriminator updates when its loss drops below ``0.3``
+        #: to implement a two time-scale update rule.
+    )
     disc_steps: int = 1
     disc_aug_prob: float = 0.0
     disc_aug_noise: float = 0.0

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -27,6 +27,7 @@ the training procedure, hyperparameter sweeps and available modules.
    discriminator_augmentation
    unrolled_discriminator
    warm_start
+   ttur
    doubly_robust
    datasets
    uncertainty

--- a/docs/ttur.rst
+++ b/docs/ttur.rst
@@ -1,0 +1,39 @@
+Two Time-Scale Update Rule (TTUR)
+================================
+
+The ``ttur`` flag of :class:`~crosslearner.training.TrainingConfig` enables a
+simple variant of the *two time-scale update rule*. After each epoch the
+training loop checks the discriminator loss. When the loss drops below ``0.3``
+the discriminator is temporarily frozen for the next epoch, allowing the
+generator to catch up without competing against an overly strong adversary.
+
+Motivation
+----------
+
+GAN optimisation can become unstable when the discriminator learns much faster
+than the generator. A dominating discriminator drives its loss close to zero,
+which leaves the generator with vanishing gradients. The two time-scale update
+rule counteracts this by updating the two networks at different speeds. This
+implementation freezes discriminator updates whenever it is already performing
+well, effectively reducing its learning rate compared to the generator.
+
+Usage
+-----
+
+Activate the scheme by passing ``ttur=True`` when constructing the training
+configuration::
+
+    train_cfg = TrainingConfig(
+        epochs=50,
+        ttur=True,
+    )
+
+When to use it
+--------------
+
+Enable ``ttur`` if you observe that the discriminator quickly achieves near-zero
+loss and the generator fails to improve. Freezing the discriminator for short
+periods gives the generator breathing room and can stabilise training on small
+or noisy datasets. Leave ``ttur`` disabled when both networks converge smoothly
+or when using alternative techniques such as gradient penalties to balance their
+learning speeds.


### PR DESCRIPTION
## Summary
- document the `ttur` option in the training configuration
- link the new doc page from the manual
- clarify the meaning of `ttur` in the config dataclass

## Testing
- `ruff check .`
- `black --check .`
- `pytest --cov=crosslearner --cov-report=xml -q`

------
https://chatgpt.com/codex/tasks/task_e_6856124b3d648324b110653af3029b18