### PR TITLE
Document ema_decay option

### DIFF
--- a/crosslearner/training/config.py
+++ b/crosslearner/training/config.py
@@ -59,7 +59,13 @@ class TrainingConfig:
     )
     use_wgan_gp: bool = False
     adv_loss: str = "bce"
-    ema_decay: Optional[float] = None
+    ema_decay: Optional[float] = (
+        None
+        #: Exponential moving average decay for generator parameters.
+        #: When set, a detached copy of the model is updated after each
+        #: optimisation step via ``p_ema = ema_decay * p_ema + (1 - ema_decay) * p``.
+        #: The EMA weights are used for evaluation and returned at the end of training.
+    )
     spectral_norm: bool = False
     feature_matching: bool = False
     label_smoothing: bool = False

--- a/docs/exponential_moving_average.rst
+++ b/docs/exponential_moving_average.rst
@@ -1,0 +1,52 @@
+Exponential Moving Average of Generator Parameters
+=================================================
+
+The ``ema_decay`` option creates a slowly-updated shadow copy of the
+generator network. After every optimisation step each non-discriminator
+parameter is blended with its previous value using
+``ema_param = ema_decay * ema_param + (1 - ema_decay) * param``.
+The resulting exponential moving average (EMA) often yields smoother
+predictions than the raw, rapidly changing weights.
+
+Motivation
+----------
+
+GAN training can be noisy: generator weights fluctuate as they react to
+the discriminator. Averaging the parameters over time reduces this
+variance and can improve generalisation. It also provides a stable model
+for computing validation metrics. The technique is lightweight and
+requires only a single extra model copy.
+
+Usage
+-----
+
+Specify ``ema_decay`` in :class:`~crosslearner.training.TrainingConfig`
+with a value between ``0`` and ``1`` (e.g. ``0.999``)::
+
+   cfg = TrainingConfig(
+       epochs=30,
+       ema_decay=0.99,
+   )
+   model = train_acx(loader, ModelConfig(p=10), cfg)
+
+During training the trainer maintains an EMA model whose parameters are
+updated after each generator step. This copy is used for validation and
+is returned when training finishes.
+
+When to use it
+--------------
+
+Enable the EMA when you observe unstable validation performance or want
+more reliable treatment effect estimates. Smaller decay values (around
+``0.9``) adapt faster but track the current weights closely, while larger
+values (``0.99`` or ``0.999``) provide stronger smoothing. If memory is
+limited or you do not need extra stability set ``ema_decay`` to ``None``
+(the default) to disable the feature.
+
+References
+----------
+
+.. [Polyak1992] Polyak, B., & Juditsky, A. *Acceleration of stochastic
+   approximation by averaging.* SIAM Journal on Control and Optimization,
+   1992. Introduces the idea of averaging iterates for variance reduction.
+

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -18,6 +18,7 @@ the training procedure, hyperparameter sweeps and available modules.
    gradient_reversal
    feature_matching
    spectral_norm
+   exponential_moving_average
    weight_clipping
    wgan_gp
    r1_r2_regularization


### PR DESCRIPTION
## Summary
- add documentation for the exponential moving average (ema_decay)
- reference new doc page from index
- document ema_decay field in `TrainingConfig`

## Testing
- `ruff check .`
- `black --check .`
- `pytest --cov=crosslearner --cov-report=xml -q`

------
https://chatgpt.com/codex/tasks/task_e_685620a9bed083248a064322e5b6814c