### PR TITLE
Document training history flag

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -35,6 +35,7 @@ the training procedure, hyperparameter sweeps and available modules.
    datasets
    uncertainty
    risk_early_stopping
+   training_history
    tensorboard_logging
 
 

--- a/docs/training_history.rst
+++ b/docs/training_history.rst
@@ -1,0 +1,42 @@
+Tracking Training History
+========================
+
+The ``return_history`` option of :class:`~crosslearner.training.TrainingConfig`
+determines whether :func:`~crosslearner.training.train_acx` returns a
+``History`` object alongside the trained model.  ``History`` is a list of
+:class:`~crosslearner.training.EpochStats` dataclasses recording losses and
+validation metrics for each epoch.
+
+Motivation
+----------
+
+Analysing how losses evolve can reveal mode collapse or overfitting that is not
+obvious from the final metric alone.  Access to the full history allows custom
+visualisation beyond what TensorBoard provides.
+
+Usage
+-----
+
+Set ``return_history=True`` when calling the training routine::
+
+   cfg = TrainingConfig(
+       epochs=30,
+       return_history=True,
+   )
+   model, history = train_acx(loader, ModelConfig(p=10), cfg)
+
+Pass ``history`` to :func:`crosslearner.visualization.plot_losses` or
+implement your own analytics.
+
+When to use it
+--------------
+
+Enable ``return_history`` during experimentation or when you need to log metrics
+for offline analysis.  Disable it in production training loops to avoid the
+additional return value and keep the interface simple.
+
+References
+----------
+
+.. [Abadi2016] Abadi, M., et al. *TensorFlow: A System for Large-Scale Machine
+   Learning.* OSDI 2016. Discusses tracking and visualising training metrics.


### PR DESCRIPTION
## Summary
- add documentation for the `return_history` flag used by `train_acx`
- link new page from the docs index

## Testing
- `ruff check .`
- `black --check .`
- `pytest --cov=crosslearner --cov-report=xml -q`

------
https://chatgpt.com/codex/tasks/task_e_68562429f1088324b31cec88c1aa31e5