### PR TITLE
Extend training visualisation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,4 +68,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   arguments
 - Added options to log gradient norms, learning rates and weight histograms for
   improved training diagnostics
+- Extended visualisation utilities to plot auxiliary losses, gradient norms and
+  learning rate schedules
 

--- a/README.md
+++ b/README.md
@@ -168,8 +168,10 @@ Use the config file as a starting point for your own experiments on IHDP, ACIC o
 ## Visualisation
 
 The `History` returned by `train_acx` can be passed to
-`crosslearner.visualization.plot_losses` to plot generator and discriminator
-losses.  The module also provides several utilities for exploring model
+`crosslearner.visualization.plot_losses` to plot generator, discriminator and
+auxiliary losses. Gradient norms and learning rates can be visualised with
+`plot_grad_norms` and `plot_learning_rates`. The module also provides several
+utilities for exploring model
 behaviour:
 
 - `scatter_tau` produces a scatter plot of predicted versus true treatment

--- a/crosslearner/__init__.py
+++ b/crosslearner/__init__.py
@@ -15,6 +15,8 @@ from .visualization import (
     plot_covariate_balance,
     plot_propensity_overlap,
     plot_residuals,
+    plot_grad_norms,
+    plot_learning_rates,
     plot_partial_dependence,
     plot_ice,
 )
@@ -33,6 +35,8 @@ __all__ = [
     "plot_covariate_balance",
     "plot_propensity_overlap",
     "plot_residuals",
+    "plot_grad_norms",
+    "plot_learning_rates",
     "plot_partial_dependence",
     "plot_ice",
     "ExperimentManager",

--- a/crosslearner/visualization.py
+++ b/crosslearner/visualization.py
@@ -18,12 +18,29 @@ def plot_losses(history: History):
         Matplotlib figure with the loss trajectories.
     """
     epochs = [h.epoch for h in history]
-    fig, ax = plt.subplots()
-    ax.plot(epochs, [h.loss_d for h in history], label="discriminator")
-    ax.plot(epochs, [h.loss_g for h in history], label="generator")
-    ax.set_xlabel("epoch")
-    ax.set_ylabel("loss")
-    ax.legend()
+    fig, ax1 = plt.subplots()
+    ax1.plot(epochs, [h.loss_d for h in history], label="discriminator")
+    ax1.plot(epochs, [h.loss_g for h in history], label="generator")
+    ax1.plot(epochs, [h.loss_y for h in history], label="outcome")
+    ax1.plot(epochs, [h.loss_cons for h in history], label="consistency")
+    ax1.plot(epochs, [h.loss_adv for h in history], label="adversarial")
+    ax1.set_xlabel("epoch")
+    ax1.set_ylabel("loss")
+    has_val = any(h.val_pehe is not None for h in history)
+    if has_val:
+        ax2 = ax1.twinx()
+        ax2.plot(
+            epochs,
+            [h.val_pehe if h.val_pehe is not None else float("nan") for h in history],
+            "k--",
+            label="val_pehe",
+        )
+        ax2.set_ylabel("PEHE")
+        lines1, labels1 = ax1.get_legend_handles_labels()
+        lines2, labels2 = ax2.get_legend_handles_labels()
+        ax2.legend(lines1 + lines2, labels1 + labels2)
+    else:
+        ax1.legend()
     fig.tight_layout()
     return fig
 
@@ -236,5 +253,37 @@ def plot_ice(
         ax.plot(vals.cpu(), ice[:, i].cpu(), color="gray", alpha=0.3)
     ax.set_xlabel(f"feature {feature}")
     ax.set_ylabel("predicted tau")
+    fig.tight_layout()
+    return fig
+
+
+def plot_grad_norms(history: History) -> plt.Figure:
+    """Return a matplotlib Figure with gradient norm curves."""
+
+    epochs = [h.epoch for h in history]
+    fig, ax = plt.subplots()
+    if any(h.grad_norm_g is not None for h in history):
+        ax.plot(epochs, [h.grad_norm_g for h in history], label="generator")
+    if any(h.grad_norm_d is not None for h in history):
+        ax.plot(epochs, [h.grad_norm_d for h in history], label="discriminator")
+    ax.set_xlabel("epoch")
+    ax.set_ylabel("gradient norm")
+    ax.legend()
+    fig.tight_layout()
+    return fig
+
+
+def plot_learning_rates(history: History) -> plt.Figure:
+    """Return a matplotlib Figure with learning rate schedules."""
+
+    epochs = [h.epoch for h in history]
+    fig, ax = plt.subplots()
+    if any(h.lr_g is not None for h in history):
+        ax.plot(epochs, [h.lr_g for h in history], label="generator")
+    if any(h.lr_d is not None for h in history):
+        ax.plot(epochs, [h.lr_d for h in history], label="discriminator")
+    ax.set_xlabel("epoch")
+    ax.set_ylabel("learning rate")
+    ax.legend()
     fig.tight_layout()
     return fig

--- a/docs/training_history.rst
+++ b/docs/training_history.rst
@@ -25,8 +25,10 @@ Set ``return_history=True`` when calling the training routine::
    )
    model, history = train_acx(loader, ModelConfig(p=10), cfg)
 
-Pass ``history`` to :func:`crosslearner.visualization.plot_losses` or
-implement your own analytics.
+Pass ``history`` to :func:`crosslearner.visualization.plot_losses` to visualise
+losses over time. Additional helpers ``plot_grad_norms`` and
+``plot_learning_rates`` allow inspecting gradient norms and optimiser
+learning rates. You can also implement your own analytics.
 
 When to use it
 --------------

--- a/tests/test_visualization.py
+++ b/tests/test_visualization.py
@@ -11,6 +11,8 @@ from crosslearner.visualization import (
     plot_covariate_balance,
     plot_propensity_overlap,
     plot_residuals,
+    plot_grad_norms,
+    plot_learning_rates,
     plot_cate_calibration,
     plot_partial_dependence,
     plot_ice,
@@ -103,5 +105,41 @@ def test_plot_ice_returns_figure():
     model = ACX(p=2)
     X = torch.randn(5, 2)
     fig = plot_ice(model, X, feature=1)
+    assert fig is not None
+    matplotlib.pyplot.close(fig)
+
+
+def test_plot_grad_norms_returns_figure():
+    hist = [
+        EpochStats(
+            epoch=0,
+            loss_d=0.0,
+            loss_g=0.0,
+            loss_y=0.0,
+            loss_cons=0.0,
+            loss_adv=0.0,
+            grad_norm_g=1.0,
+            grad_norm_d=2.0,
+        )
+    ]
+    fig = plot_grad_norms(hist)
+    assert fig is not None
+    matplotlib.pyplot.close(fig)
+
+
+def test_plot_learning_rates_returns_figure():
+    hist = [
+        EpochStats(
+            epoch=0,
+            loss_d=0.0,
+            loss_g=0.0,
+            loss_y=0.0,
+            loss_cons=0.0,
+            loss_adv=0.0,
+            lr_g=1e-3,
+            lr_d=1e-3,
+        )
+    ]
+    fig = plot_learning_rates(hist)
     assert fig is not None
     matplotlib.pyplot.close(fig)


### PR DESCRIPTION
## Summary
- add auxiliary metrics to `plot_losses`
- export new visualisation helpers
- add `plot_grad_norms` and `plot_learning_rates`
- document visualisation metrics
- test new plotting functions

## Testing
- `ruff check .`
- `black --check .`
- `pytest --cov=crosslearner --cov-report=xml -q`


------
https://chatgpt.com/codex/tasks/task_e_685680ff75408324be9f72ba47536c87