### PR TITLE
Add mixture-of-experts outcome heads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `crosslearner-benchmark` command comparing ACX to baseline models
 - Added PacGAN-style discriminator packing via `disc_pack` configuration
 - Unified benchmark CLI and baseline comparison
+- Added mixture-of-experts heads via ``moe_experts`` and ``moe_entropy_weight``
 - Baseline MLPRegressors now train until convergence
 - Added hinge and least-squares GAN losses via `adv_loss` option
 - Added exponential moving average (`ema_decay`) for generator parameters

--- a/crosslearner/training/config.py
+++ b/crosslearner/training/config.py
@@ -32,6 +32,7 @@ class ModelConfig:
         1  #: Number of samples concatenated for PacGAN-style discriminator.
     )
     batch_norm: bool = False
+    moe_experts: int = 1  #: Number of expert pairs for mixture-of-experts heads.
 
 
 @dataclass
@@ -110,6 +111,7 @@ class TrainingConfig:
     noise_std: float = 0.0
     noise_consistency_weight: float = 0.0
     rep_consistency_weight: float = 0.0
+    moe_entropy_weight: float = 0.0  #: Weight for gating entropy regularization.
     rep_momentum: float = 0.99
     adv_t_weight: float = (
         0.0

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -29,6 +29,7 @@ the training procedure, hyperparameter sweeps and available modules.
    contrastive_loss
    mmd_regularization
    representation_disentanglement
+   mixture_of_experts
    consistency_regularization
    discriminator_augmentation
    unrolled_discriminator

--- a/docs/mixture_of_experts.rst
+++ b/docs/mixture_of_experts.rst
@@ -1,0 +1,22 @@
+Mixture-of-Experts Potential-Outcome Heads
+=========================================
+
+Setting ``moe_experts`` greater than ``1`` in :class:`~crosslearner.training.ModelConfig`
+replaces the single potential-outcome heads with a set of expert pairs. A gating
+network ``g(x)`` softly selects experts for each sample and the final predictions
+are the weighted sum of their outputs.
+
+This allows the model to specialise to heterogeneous sub-populations while
+sharing a common representation. To encourage sparse selections, the trainer adds
+an entropy penalty on the gating distribution controlled by ``moe_entropy_weight``
+from :class:`~crosslearner.training.TrainingConfig`::
+
+   cfg = TrainingConfig(
+       epochs=30,
+       moe_entropy_weight=0.1,
+   )
+   model_cfg = ModelConfig(p=10, moe_experts=4)
+   model = train_acx(loader, model_cfg, cfg)
+
+Existing adversarial and consistency losses operate on the aggregated outputs so
+no other changes are required.

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -54,3 +54,15 @@ def test_acx_disc_pack():
     model = ACX(p=3, disc_pack=2)
     assert model.disc_pack == 2
     assert model.disc.net[0][0].in_features == 2 * (64 + 2)
+
+
+def test_acx_moe_forward():
+    model = ACX(p=3, moe_experts=2)
+    X = torch.randn(2, 3)
+    h, m0, m1, tau = model(X)
+    assert h.shape == (2, 64)
+    assert m0.shape == (2, 1)
+    assert m1.shape == (2, 1)
+    assert tau.shape == (2, 1)
+    assert model.use_moe
+    assert model.moe.gates.shape == (2, 2)

--- a/tests/test_training.py
+++ b/tests/test_training.py
@@ -350,6 +350,14 @@ def test_train_acx_r1_r2_unrolled():
     cfg = TrainingConfig(epochs=1, r1_gamma=0.1, verbose=False)
     model = train_acx(loader, model_cfg, cfg, device="cpu")
     assert isinstance(model, ACX)
+
+
+def test_train_acx_moe_heads():
+    loader, _ = get_toy_dataloader(batch_size=4, n=8, p=4)
+    model_cfg = ModelConfig(p=4, moe_experts=2)
+    cfg = TrainingConfig(epochs=1, moe_entropy_weight=0.1, verbose=False)
+    model = train_acx(loader, model_cfg, cfg, device="cpu")
+    assert model.use_moe
     cfg = TrainingConfig(epochs=1, r2_gamma=0.1, verbose=False)
     model = train_acx(loader, model_cfg, cfg, device="cpu")
     assert isinstance(model, ACX)


### PR DESCRIPTION
## Summary
- implement `MOEHeads` and `NullMOE` modules
- extend `ACX` to optionally use a mixture-of-experts for potential outcomes
- add `moe_experts` and `moe_entropy_weight` configuration options
- apply gating entropy penalty in the trainer
- document the feature and add tests

## Testing
- `ruff check .`
- `black --check .`
- `pytest --cov=crosslearner --cov-report=xml -q`

------
https://chatgpt.com/codex/tasks/task_e_685744803a348324897b73bd2ca7a39e