### PR TITLE
Fix gating state leak in MOE heads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,4 +71,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   improved training diagnostics
 - Extended visualisation utilities to plot auxiliary losses, gradient norms and
   learning rate schedules
+- Detached MOE gating weights to avoid memory leaks and added unit tests for
+  ``MOEHeads`` gating behaviour
 

--- a/crosslearner/models/acx.py
+++ b/crosslearner/models/acx.py
@@ -185,7 +185,7 @@ class MOEHeads(nn.Module):
 
     def forward(self, x: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
         w = self.softmax(self.gate(x))
-        self._gates = w
+        self._gates = w.detach()
         m0 = torch.stack([head(x) for head in self.mu0], dim=1).squeeze(-1)
         m1 = torch.stack([head(x) for head in self.mu1], dim=1).squeeze(-1)
         m0 = (w * m0).sum(dim=1, keepdim=True)

--- a/tests/test_moe_heads.py
+++ b/tests/test_moe_heads.py
@@ -1,0 +1,15 @@
+import torch
+
+from crosslearner.models.acx import MOEHeads
+
+
+def test_moe_heads_gating_weights_sum_to_one():
+    moe = MOEHeads(in_dim=4, num_experts=3, hidden=(8,))
+    x = torch.randn(5, 4)
+    m0, m1 = moe(x)
+    w = moe.gates
+    assert w.shape == (5, 3)
+    assert torch.allclose(w.sum(dim=1), torch.ones(5))
+    assert not w.requires_grad
+    assert m0.shape == (5, 1)
+    assert m1.shape == (5, 1)


### PR DESCRIPTION
## Summary
- avoid leaking autograd graphs in `MOEHeads` by detaching gates
- add unit test covering `MOEHeads` gating behaviour
- document the change in `CHANGELOG`

## Testing
- `ruff check .`
- `black --check .`
- `pytest --cov=crosslearner --cov-report=xml -q`

------
https://chatgpt.com/codex/tasks/task_e_68574da80e808324b6741c2b7333c686