### PR TITLE
Fix epistemic consistency setup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,4 +75,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ``MOEHeads`` gating behaviour
 - Added epistemic-aware consistency loss via ``epistemic_consistency`` and
   ``tau_heads`` options
+- Passed ``tau_heads`` from ``ModelConfig`` to ``ACX`` and validate when
+  ``epistemic_consistency`` is enabled
 

--- a/crosslearner/training/trainer.py
+++ b/crosslearner/training/trainer.py
@@ -93,7 +93,10 @@ class ACXTrainer:
             disc_pack=model_cfg.disc_pack,
             batch_norm=model_cfg.batch_norm,
             moe_experts=model_cfg.moe_experts,
+            tau_heads=model_cfg.tau_heads,
         ).to(self.device)
+        if train_cfg.epistemic_consistency and self.model.num_tau_heads <= 1:
+            raise ValueError("epistemic_consistency requires ModelConfig.tau_heads > 1")
         if train_cfg.spectral_norm:
             apply_spectral_norm(self.model)
 
@@ -120,6 +123,7 @@ class ACXTrainer:
                 disc_pack=model_cfg.disc_pack,
                 batch_norm=model_cfg.batch_norm,
                 moe_experts=model_cfg.moe_experts,
+                tau_heads=model_cfg.tau_heads,
             ).to(self.device)
             if train_cfg.spectral_norm:
                 apply_spectral_norm(self.ema_model)


### PR DESCRIPTION
## Summary
- pass `tau_heads` to ACX models during training
- validate that `epistemic_consistency` requires more than one head
- document the change in CHANGELOG

## Testing
- `ruff check .`
- `black --check .`
- `pytest --cov=crosslearner --cov-report=xml -q`

------
https://chatgpt.com/codex/tasks/task_e_68575613a84c8324b9efadd76e5d3117