### PR TITLE
Improve ModelConfig validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,4 +75,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ``MOEHeads`` gating behaviour
 - Added epistemic-aware consistency loss via ``epistemic_consistency`` and
   ``tau_heads`` options
+- Validated ``ModelConfig.tau_heads`` to be at least 1 and added a regression test
 

--- a/crosslearner/training/config.py
+++ b/crosslearner/training/config.py
@@ -35,6 +35,10 @@ class ModelConfig:
     moe_experts: int = 1  #: Number of expert pairs for mixture-of-experts heads.
     tau_heads: int = 1  #: Number of effect heads for epistemic ensembling.
 
+    def __post_init__(self) -> None:
+        if self.tau_heads < 1:
+            raise ValueError("tau_heads must be >= 1")
+
 
 @dataclass
 class TrainingConfig:

--- a/docs/consistency_regularization.rst
+++ b/docs/consistency_regularization.rst
@@ -57,7 +57,7 @@ When ``epistemic_consistency`` is enabled the consistency weight is scaled
 by the ensemble variance of the treatment effect head. This down-weights the
 penalty in regions where the model is uncertain, preventing over-regularisation
 on scarcely observed samples. Configure the number of ensemble heads via
-``ModelConfig.tau_heads``.
+``ModelConfig.tau_heads`` (must be at least ``1``).
 
 Example usage::
 

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -1,6 +1,8 @@
 import torch
 import torch.nn as nn
+import pytest
 from crosslearner.models.acx import ACX
+from crosslearner.training.config import ModelConfig
 
 
 def test_acx_forward_shapes():
@@ -75,3 +77,8 @@ def test_acx_tau_variance():
     var = model.tau_variance
     assert var.shape == (4, 1)
     assert torch.any(var >= 0)
+
+
+def test_model_config_invalid_tau_heads():
+    with pytest.raises(ValueError):
+        ModelConfig(p=2, tau_heads=0)


### PR DESCRIPTION
## Summary
- validate `tau_heads` in `ModelConfig`
- document the minimum value in consistency regularisation docs
- add regression test for invalid `tau_heads`

## Testing
- `ruff check .`
- `black --check .`
- `pytest --cov=crosslearner --cov-report=xml -q`

------
https://chatgpt.com/codex/tasks/task_e_68575b8ed900832481e86e8f6937e16f