### PR TITLE
Improve epistemic consistency support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,4 +77,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ``tau_heads`` options
 - Passed ``tau_heads`` from ``ModelConfig`` to ``ACX`` and validate when
   ``epistemic_consistency`` is enabled
+- Added ``effect_consistency_weight`` property and tests for tau head validation
 

--- a/crosslearner/models/acx.py
+++ b/crosslearner/models/acx.py
@@ -523,6 +523,11 @@ class ACX(nn.Module):
         """Variance of ensemble treatment effect predictions from last forward."""
         return self._tau_var
 
+    @property
+    def effect_consistency_weight(self) -> torch.Tensor:
+        """Inverse variance weight used for epistemic consistency loss."""
+        return 1.0 / (1.0 + self._tau_var.detach())
+
     def moe_entropy(self) -> torch.Tensor:
         """Entropy of the gating distribution."""
 

--- a/crosslearner/training/trainer.py
+++ b/crosslearner/training/trainer.py
@@ -592,7 +592,7 @@ class ACXTrainer:
             m_obs = torch.where(Tb.bool(), m1, m0)
             loss_y = mse(m_obs, Yb)
             if cfg.epistemic_consistency:
-                weight = 1.0 / (1.0 + model.tau_variance.detach())
+                weight = model.effect_consistency_weight
                 loss_cons = ((tau - (m1 - m0)) ** 2 * weight).mean()
             else:
                 loss_cons = mse(tau, m1 - m0)

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -75,3 +75,12 @@ def test_acx_tau_variance():
     var = model.tau_variance
     assert var.shape == (4, 1)
     assert torch.any(var >= 0)
+
+
+def test_acx_effect_consistency_weight():
+    model = ACX(p=2, tau_heads=3)
+    X = torch.randn(3, 2)
+    _ = model(X)
+    weight = model.effect_consistency_weight
+    expected = 1.0 / (1.0 + model.tau_variance)
+    assert torch.allclose(weight, expected)

--- a/tests/test_training.py
+++ b/tests/test_training.py
@@ -431,6 +431,14 @@ def test_train_acx_epistemic_consistency():
     assert isinstance(model, ACX)
 
 
+def test_epistemic_consistency_requires_multiple_heads():
+    loader, _ = get_toy_dataloader(batch_size=4, n=8, p=4)
+    model_cfg = ModelConfig(p=4, tau_heads=1)
+    cfg = TrainingConfig(epochs=1, epistemic_consistency=True, verbose=False)
+    with pytest.raises(ValueError):
+        train_acx(loader, model_cfg, cfg, device="cpu")
+
+
 def test_adaptive_regularization_updates_lambda():
     loader, _ = get_toy_dataloader(batch_size=4, n=16, p=4)
     model_cfg = ModelConfig(p=4)


### PR DESCRIPTION
## Summary
- expose `effect_consistency_weight` on `ACX`
- use that property in the trainer
- test tau head validation and new property

## Testing
- `ruff check .`
- `black --check .`
- `pytest --cov=crosslearner --cov-report=xml -q`

------
https://chatgpt.com/codex/tasks/task_e_68577fd7c1a8832485b96fb886520d24