### PR TITLE
Fix tau variance gradient tracking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,4 +78,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Passed ``tau_heads`` from ``ModelConfig`` to ``ACX`` and validate when
   ``epistemic_consistency`` is enabled
 - Added ``effect_consistency_weight`` property and tests for tau head validation
+- Stopped tracking gradients for ``tau_variance`` to reduce memory usage
 

--- a/crosslearner/models/acx.py
+++ b/crosslearner/models/acx.py
@@ -437,7 +437,8 @@ class ACX(nn.Module):
             m0, m1 = self.moe(h)
             tau_samples = torch.stack([head(h) for head in self.tau_heads], dim=2)
         tau = tau_samples.mean(dim=2)
-        self._tau_var = tau_samples.var(dim=2, unbiased=False)
+        with torch.no_grad():
+            self._tau_var = tau_samples.var(dim=2, unbiased=False)
         return h, m0, m1, tau
 
     @torch.jit.export

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -75,6 +75,7 @@ def test_acx_tau_variance():
     var = model.tau_variance
     assert var.shape == (4, 1)
     assert torch.any(var >= 0)
+    assert not var.requires_grad
 
 
 def test_acx_effect_consistency_weight():


### PR DESCRIPTION
## Summary
- stop tracking gradients for `tau_variance`
- assert tau variance has no gradient
- note change in changelog

## Testing
- `ruff check .`
- `black --check .`
- `pytest --cov=crosslearner --cov-report=xml -q`

------
https://chatgpt.com/codex/tasks/task_e_6857a9ef76bc83248993817ce15de604