### PR TITLE
Improve mixture-of-experts tests

### DIFF
--- a/tests/test_moe_heads.py
+++ b/tests/test_moe_heads.py
@@ -13,3 +13,12 @@ def test_moe_heads_gating_weights_sum_to_one():
     assert not w.requires_grad
     assert m0.shape == (5, 1)
     assert m1.shape == (5, 1)
+
+
+def test_moe_entropy_matches_manual_computation():
+    moe = MOEHeads(in_dim=6, num_experts=4, hidden=(10,))
+    x = torch.randn(3, 6)
+    moe(x)
+    w = moe.gates
+    expected = -(w.clamp_min(1e-12) * w.clamp_min(1e-12).log()).sum(dim=1).mean()
+    assert torch.allclose(moe.entropy(), expected)


### PR DESCRIPTION
## Summary
- expand unit tests for mixture-of-experts heads

## Testing
- `ruff check .`
- `black --check .`
- `pytest --cov=crosslearner --cov-report=xml -q`

------
https://chatgpt.com/codex/tasks/task_e_6857b20ccfdc83248c0a8270cf1a3326