### PR TITLE
Improve active augmentation compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,4 +83,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   related options
 - Active augmentation now preserves ``DataLoader`` settings when appending
   pseudo data
+- Active augmentation now handles optional ``DataLoader`` arguments for
+  compatibility with older PyTorch versions
 


### PR DESCRIPTION
## Summary
- ensure optional DataLoader attributes are only used if supported
- document compatibility update in CHANGELOG

## Testing
- `ruff check crosslearner/training/trainer.py`
- `black --check crosslearner/training/trainer.py`
- `pytest tests/test_training.py::test_active_counterfactual_augmentation -q`
- `pytest --cov=crosslearner --cov-report=xml -q`


------
https://chatgpt.com/codex/tasks/task_e_6857e5a625b483248c41d802f32b96c9