### PR TITLE
Improve representation pretraining docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,4 +88,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Disabled gradient tracking for model parameters during active counterfactual
   search to reduce overhead
 - Added optional representation pre-training via masked feature reconstruction
+- Documented representation pretraining options and updated config comments
 

--- a/crosslearner/training/config.py
+++ b/crosslearner/training/config.py
@@ -115,10 +115,26 @@ class TrainingConfig:
     rep_consistency_weight: float = 0.0
     moe_entropy_weight: float = 0.0  #: Weight for gating entropy regularization.
     rep_momentum: float = 0.99
-    pretrain_epochs: int = 0
-    pretrain_mask_prob: float = 0.15
-    pretrain_lr: float | None = None
-    finetune_lr: float | None = None
+    pretrain_epochs: int = (
+        0
+        #: Number of epochs to pretrain the encoder using masked feature
+        #: reconstruction. ``0`` disables pretraining.
+    )
+    pretrain_mask_prob: float = (
+        0.15
+        #: Fraction of input features randomly masked during representation
+        #: pretraining.
+    )
+    pretrain_lr: float | None = (
+        None
+        #: Optional learning rate for the encoder during pretraining. ``None``
+        #: uses ``lr_g``.
+    )
+    finetune_lr: float | None = (
+        None
+        #: Optional learning rate for the encoder after pretraining. ``None``
+        #: scales ``lr_g`` by ``0.1``.
+    )
     adv_t_weight: float = (
         0.0
         #: Weight for predicting treatment from the confounder and

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -35,6 +35,7 @@ the training procedure, hyperparameter sweeps and available modules.
    active_counterfactual_augmentation
    unrolled_discriminator
    warm_start
+   representation_pretraining
    ttur
    doubly_robust
    datasets

--- a/docs/representation_pretraining.rst
+++ b/docs/representation_pretraining.rst
@@ -1,0 +1,26 @@
+Representation Pretraining
+==========================
+
+``pretrain_epochs`` enables an unsupervised warm-up phase where the encoder
+is trained to reconstruct masked features.  During this stage the model is fed
+corrupted inputs from :class:`crosslearner.datasets.MaskedFeatureDataset` and a
+linear decoder tries to predict the original features.  Only the shared
+representation network ``phi`` and this decoder are updated.
+
+``pretrain_mask_prob`` controls the fraction of features set to zero, mimicking
+missing covariates.  ``pretrain_lr`` can override the encoder's learning rate
+for this phase while ``finetune_lr`` specifies the learning rate for subsequent
+training.  When ``finetune_lr`` is not provided ``lr_g`` is reduced by a factor
+of ``0.1`` after pretraining.
+
+This initialization can stabilise adversarial training on small datasets or
+when the encoder has many parameters.
+
+Example usage::
+
+   cfg = TrainingConfig(
+       pretrain_epochs=5,
+       pretrain_mask_prob=0.2,
+       epochs=30,
+   )
+   model = train_acx(loader, ModelConfig(p=10), cfg)

--- a/tests/test_training.py
+++ b/tests/test_training.py
@@ -500,5 +500,5 @@ def test_pretrain_representation():
     loader, _ = get_toy_dataloader(batch_size=4, n=8, p=4)
     model_cfg = ModelConfig(p=4)
     cfg = TrainingConfig(pretrain_epochs=1, epochs=1, verbose=False)
-    model = train_acx(loader, model_cfg, cfg, device="cpu")
-    assert isinstance(model, ACX)
+    train_acx(loader, model_cfg, cfg, device="cpu")
+    assert cfg.lr_g < 1e-3


### PR DESCRIPTION
## Summary
- document representation pretraining options
- link docs from the index
- verify LR update during pretraining in tests
- explain configuration fields for pretraining in `TrainingConfig`

## Testing
- `ruff check .`
- `black --check .`
- `pytest --cov=crosslearner --cov-report=xml -q`

------
https://chatgpt.com/codex/tasks/task_e_6858aa069ba48324b396318e335e28f8