### PR TITLE
Add tau head bias option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -89,4 +89,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   search to reduce overhead
 - Added optional representation pre-training via masked feature reconstruction
 - Documented representation pretraining options and updated config comments
+- Added ``tau_bias`` flag to freeze effect head biases for more stable training
 

--- a/crosslearner/training/config.py
+++ b/crosslearner/training/config.py
@@ -34,6 +34,7 @@ class ModelConfig:
     batch_norm: bool = False
     moe_experts: int = 1  #: Number of expert pairs for mixture-of-experts heads.
     tau_heads: int = 1  #: Number of effect heads for epistemic ensembling.
+    tau_bias: bool = True  #: If ``False`` freeze the effect head biases at zero.
 
 
 @dataclass

--- a/crosslearner/training/trainer.py
+++ b/crosslearner/training/trainer.py
@@ -96,6 +96,7 @@ class ACXTrainer:
             batch_norm=model_cfg.batch_norm,
             moe_experts=model_cfg.moe_experts,
             tau_heads=model_cfg.tau_heads,
+            tau_bias=model_cfg.tau_bias,
         ).to(self.device)
         if train_cfg.epistemic_consistency and self.model.num_tau_heads <= 1:
             raise ValueError("epistemic_consistency requires ModelConfig.tau_heads > 1")
@@ -126,6 +127,7 @@ class ACXTrainer:
                 batch_norm=model_cfg.batch_norm,
                 moe_experts=model_cfg.moe_experts,
                 tau_heads=model_cfg.tau_heads,
+                tau_bias=model_cfg.tau_bias,
             ).to(self.device)
             if train_cfg.spectral_norm:
                 apply_spectral_norm(self.ema_model)

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -54,6 +54,7 @@ the training procedure, hyperparameter sweeps and available modules.
    active_counterfactual_augmentation
    unrolled_discriminator
    mixture_of_experts
+   tau_head_bias
    representation_pretraining
    representation_disentanglement
    doubly_robust

--- a/docs/tau_head_bias.rst
+++ b/docs/tau_head_bias.rst
@@ -1,0 +1,31 @@
+Effect Head Bias
+================
+
+``tau_bias`` controls whether the effect heads learn a separate bias term.
+When set to ``False`` all biases are fixed at ``0`` so the model's treatment
+
+effect predictions rely purely on the learned features. This can reduce
+run-to-run variance in small data regimes where a constantly shifting offset
+can destabilise training.
+
+Usage
+-----
+
+Set ``tau_bias=False`` in :class:`~crosslearner.training.ModelConfig`::
+
+   model_cfg = ModelConfig(p=10, tau_bias=False)
+   model = ACX(
+       model_cfg.p,
+       tau_bias=model_cfg.tau_bias,
+   )
+
+Alternatively, create a :class:`~crosslearner.models.ACX` instance directly::
+
+   model = ACX(p=10, tau_bias=False)
+
+When to use it
+--------------
+
+Disable the bias when the effect head tends to learn a large constant offset
+across different runs. Fixing the bias to ``0`` forces the model to learn the
+scaling from the covariates instead of relying on a free parameter.

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -85,3 +85,10 @@ def test_acx_effect_consistency_weight():
     weight = model.effect_consistency_weight
     expected = 1.0 / (1.0 + model.tau_variance)
     assert torch.allclose(weight, expected)
+
+
+def test_acx_zero_tau_bias():
+    model = ACX(p=3, tau_bias=False)
+    for head in model.tau_heads:
+        assert torch.all(head.out.bias == 0)
+        assert not head.out.bias.requires_grad


### PR DESCRIPTION
## Summary
- allow the ACX model to fix the effect head biases to zero via `tau_bias`
- expose the flag in `ModelConfig` and pass through the trainer
- document the new option and update the changelog
- test disabling the tau head bias

## Testing
- `ruff check .`
- `black --check .`
- `pytest --cov=crosslearner --cov-report=xml -q`


------
https://chatgpt.com/codex/tasks/task_e_68590259db348324b84a50fe7424afb3