### PR TITLE
Add ACX ensemble helpers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,4 +90,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added optional representation pre-training via masked feature reconstruction
 - Documented representation pretraining options and updated config comments
 - Added ``tau_bias`` flag to freeze effect head biases for more stable training
+- Added ``train_acx_ensemble`` and ``predict_tau_ensemble`` helpers for model
+  ensembling
 

--- a/README.md
+++ b/README.md
@@ -214,6 +214,16 @@ from crosslearner.evaluation import predict_tau_mc_dropout
 mean, std = predict_tau_mc_dropout(model, X, passes=50)
 ```
 
+Alternatively you can train multiple models and average their predictions:
+
+```python
+from crosslearner.training import train_acx_ensemble
+from crosslearner.evaluation import predict_tau_ensemble
+
+models = train_acx_ensemble(loader, model_cfg, train_cfg, n_models=5)
+mean, std = predict_tau_ensemble(models, X)
+```
+
 ## Documentation
 
 Hosted documentation is available at [https://mattsq.github.io/crosslearner/](https://mattsq.github.io/crosslearner/).

--- a/crosslearner/__init__.py
+++ b/crosslearner/__init__.py
@@ -1,10 +1,10 @@
 """Public API for the ``crosslearner`` package."""
 
 from .datasets import get_toy_dataloader, get_complex_dataloader
-from .training.train_acx import train_acx
+from .training.train_acx import train_acx, train_acx_ensemble
 from .training.history import EpochStats, History
 from .evaluation.evaluate import evaluate
-from .evaluation.uncertainty import predict_tau_mc_dropout
+from .evaluation.uncertainty import predict_tau_mc_dropout, predict_tau_ensemble
 from .experiments import ExperimentManager, cross_validate_acx
 from .utils import set_seed, default_device
 from .export import export_model
@@ -25,10 +25,12 @@ __all__ = [
     "get_toy_dataloader",
     "get_complex_dataloader",
     "train_acx",
+    "train_acx_ensemble",
     "EpochStats",
     "History",
     "evaluate",
     "predict_tau_mc_dropout",
+    "predict_tau_ensemble",
     "plot_losses",
     "scatter_tau",
     "plot_tau_distribution",

--- a/crosslearner/evaluation/__init__.py
+++ b/crosslearner/evaluation/__init__.py
@@ -9,7 +9,7 @@ from .metrics import (
     att_error,
     bootstrap_ci,
 )
-from .uncertainty import predict_tau_mc_dropout
+from .uncertainty import predict_tau_mc_dropout, predict_tau_ensemble
 
 __all__ = [
     "evaluate",
@@ -21,5 +21,6 @@ __all__ = [
     "att_error",
     "bootstrap_ci",
     "predict_tau_mc_dropout",
+    "predict_tau_ensemble",
     "estimate_propensity",
 ]

--- a/crosslearner/evaluation/uncertainty.py
+++ b/crosslearner/evaluation/uncertainty.py
@@ -34,3 +34,20 @@ def predict_tau_mc_dropout(
     std = stacked.std(dim=0)
     model.eval()
     return mean, std
+
+
+@torch.no_grad()
+def predict_tau_ensemble(
+    models: Tuple[ACX, ...] | list[ACX], X: torch.Tensor
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    """Return mean and standard deviation of ensemble CATE predictions."""
+
+    samples = []
+    for model in models:
+        device = model_device(model)
+        _, _, _, tau = model(X.to(device))
+        samples.append(tau.cpu())
+    stacked = torch.stack(samples)
+    mean = stacked.mean(dim=0)
+    std = stacked.std(dim=0)
+    return mean, std

--- a/crosslearner/training/train_acx.py
+++ b/crosslearner/training/train_acx.py
@@ -22,3 +22,38 @@ def train_acx(
 
     trainer = ACXTrainer(model_config, training_config, device=device, seed=seed)
     return trainer.train(loader)
+
+
+def train_acx_ensemble(
+    loader: DataLoader,
+    model_config: ModelConfig,
+    training_config: TrainingConfig,
+    *,
+    n_models: int,
+    device: Optional[str] = None,
+    seed: int | None = None,
+) -> list[ACX] | tuple[list[ACX], list[History]]:
+    """Train ``n_models`` independent ACX models.
+
+    Each model is trained with the same configuration but with incremented
+    random seeds for reproducibility.
+    """
+
+    models: list[ACX] = []
+    histories: list[History] = []
+    for i in range(n_models):
+        model_seed = None if seed is None else seed + i
+        trainer = ACXTrainer(
+            model_config,
+            training_config,
+            device=device,
+            seed=model_seed,
+        )
+        result = trainer.train(loader)
+        if training_config.return_history:
+            model, history = result  # type: ignore[misc]
+            models.append(model)
+            histories.append(history)
+        else:
+            models.append(result)  # type: ignore[arg-type]
+    return (models, histories) if training_config.return_history else models

--- a/docs/uncertainty.rst
+++ b/docs/uncertainty.rst
@@ -11,9 +11,18 @@ Example usage::
 
     from crosslearner.evaluation import predict_tau_mc_dropout
 
-    mean, std = predict_tau_mc_dropout(model, X, passes=50)
-    lower = mean - 1.96 * std
-    upper = mean + 1.96 * std
+   mean, std = predict_tau_mc_dropout(model, X, passes=50)
+   lower = mean - 1.96 * std
+   upper = mean + 1.96 * std
+
+Ensembles of independently trained models provide an alternative estimate of
+epistemic uncertainty::
+
+    from crosslearner.training import train_acx_ensemble
+    from crosslearner.evaluation import predict_tau_ensemble
+
+    models = train_acx_ensemble(loader, model_cfg, train_cfg, n_models=5)
+    mean, std = predict_tau_ensemble(models, X)
 
 This approximates a Bayesian posterior over the model weights and yields
 pointwise credible intervals for the CATE.

--- a/tests/test_ensemble.py
+++ b/tests/test_ensemble.py
@@ -1,0 +1,35 @@
+import torch
+from crosslearner.datasets.toy import get_toy_dataloader
+from crosslearner.training import ModelConfig, TrainingConfig
+from crosslearner.training.train_acx import train_acx_ensemble
+from crosslearner.evaluation.uncertainty import predict_tau_ensemble
+from crosslearner.models.acx import ACX
+from crosslearner import set_seed
+
+
+def test_train_acx_ensemble_simple():
+    set_seed(0)
+    loader, _ = get_toy_dataloader(batch_size=4, n=16, p=3)
+    model_cfg = ModelConfig(p=3)
+    train_cfg = TrainingConfig(epochs=1)
+    models = train_acx_ensemble(
+        loader, model_cfg, train_cfg, n_models=2, device="cpu", seed=0
+    )
+    assert len(models) == 2
+    assert all(isinstance(m, ACX) for m in models)
+
+
+def test_predict_tau_ensemble_mean_std():
+    model1 = ACX(p=2)
+    model2 = ACX(p=2)
+    with torch.no_grad():
+        for p in model1.parameters():
+            p.zero_()
+        for p in model2.parameters():
+            p.zero_()
+        model1.tau.out.bias.fill_(1.0)
+        model2.tau.out.bias.fill_(2.0)
+    X = torch.zeros(3, 2)
+    mean, std = predict_tau_ensemble([model1, model2], X)
+    assert torch.allclose(mean, torch.full((3, 1), 1.5))
+    assert torch.allclose(std, torch.full((3, 1), 0.70710677))


### PR DESCRIPTION
## Summary
- support training ACX model ensembles
- expose new helper functions through the public API
- document ensemble usage in the README and uncertainty guide
- test ensemble training and prediction

## Testing
- `ruff check .`
- `black --check .`
- `pytest --cov=crosslearner --cov-report=xml -q`


------
https://chatgpt.com/codex/tasks/task_e_68590a099b80832498c7d4219e785517