### PR TITLE
Add discriminator-friendly synthetic dataset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -92,4 +92,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added ``tau_bias`` flag to freeze effect head biases for more stable training
 - Added ``train_acx_ensemble`` and ``predict_tau_ensemble`` helpers for model
   ensembling
+- Added ``get_tricky_dataloader`` providing a small imbalanced dataset for
+  testing discriminator stabilisation tricks
 

--- a/crosslearner/datasets/__init__.py
+++ b/crosslearner/datasets/__init__.py
@@ -4,6 +4,7 @@ from .toy import get_toy_dataloader
 from .complex import get_complex_dataloader
 from .synthetic import get_confounding_dataloader
 from .aircraft import get_aircraft_dataloader
+from .tricks import get_tricky_dataloader
 from .masked import MaskedFeatureDataset
 
 
@@ -60,5 +61,6 @@ __all__ = [
     "get_lalonde_dataloader",
     "get_confounding_dataloader",
     "get_aircraft_dataloader",
+    "get_tricky_dataloader",
     "MaskedFeatureDataset",
 ]

--- a/crosslearner/datasets/tricks.py
+++ b/crosslearner/datasets/tricks.py
@@ -1,0 +1,36 @@
+"""Synthetic dataset emphasising discriminator tricks."""
+
+import torch
+from torch.utils.data import DataLoader, TensorDataset
+
+
+def get_tricky_dataloader(
+    batch_size: int = 256,
+    n: int = 1000,
+    p: int = 8,
+    confounding: float = 1.0,
+    seed: int | None = None,
+):
+    """Return DataLoader for a small imbalanced synthetic dataset.
+
+    The setup deliberately introduces strong confounding and class imbalance so
+    the discriminator quickly overfits without stabilisation tricks.
+    """
+    gen = torch.Generator().manual_seed(seed) if seed is not None else None
+    X = torch.randn(n, p, generator=gen)
+    U = torch.randn(n, generator=gen)
+
+    logit = 2.5 * X[:, 0] - 2.5 * X[:, 1] + confounding * U - 1.0
+    T = torch.bernoulli(torch.sigmoid(logit), generator=gen).float()
+
+    mu0 = X[:, 0] - X[:, 1] + 0.5 * confounding * U
+    mu1 = mu0 + torch.tanh(X[:, 2]) + 1.0 * (X[:, 3] > 0).float()
+
+    Y = torch.where(T.bool(), mu1, mu0) + 0.3 * torch.randn(n, generator=gen)
+
+    loader = DataLoader(
+        TensorDataset(X, T.unsqueeze(-1), Y.unsqueeze(-1)),
+        batch_size=batch_size,
+        shuffle=True,
+    )
+    return loader, (mu0.unsqueeze(-1), mu1.unsqueeze(-1))

--- a/docs/datasets.rst
+++ b/docs/datasets.rst
@@ -22,6 +22,7 @@ Available loaders
    crosslearner.datasets.get_twins_dataloader
    crosslearner.datasets.get_lalonde_dataloader
    crosslearner.datasets.get_aircraft_dataloader
+   crosslearner.datasets.get_tricky_dataloader
 
 Dataset descriptions
 --------------------
@@ -49,3 +50,5 @@ The loaders cover both synthetic benchmarks and popular real-world datasets.
   Original LaLonde dataset with only the ATE available.
 ``get_aircraft_dataloader``
   Simulated aircraft performance data based on the Breguet range equation.
+``get_tricky_dataloader``
+  Small imbalanced synthetic dataset designed to highlight discriminator tricks.

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -3,6 +3,7 @@ from crosslearner.datasets.toy import get_toy_dataloader
 from crosslearner.datasets.complex import get_complex_dataloader
 from crosslearner.datasets.jobs import get_jobs_dataloader
 from crosslearner.datasets.aircraft import get_aircraft_dataloader
+from crosslearner.datasets.tricks import get_tricky_dataloader
 from crosslearner.datasets import ihdp, acic2016, acic2018, twins, lalonde, synthetic
 
 
@@ -154,6 +155,16 @@ def test_get_aircraft_dataloader():
     loader, (mu0, mu1) = get_aircraft_dataloader(batch_size=2, n=4, seed=0)
     X, T, Y = next(iter(loader))
     assert X.shape == (2, 5)
+    assert T.shape == (2, 1)
+    assert Y.shape == (2, 1)
+    assert mu0.shape == (4, 1)
+    assert mu1.shape == (4, 1)
+
+
+def test_get_tricky_dataloader():
+    loader, (mu0, mu1) = get_tricky_dataloader(batch_size=2, n=4, p=4, seed=0)
+    X, T, Y = next(iter(loader))
+    assert X.shape == (2, 4)
     assert T.shape == (2, 1)
     assert Y.shape == (2, 1)
     assert mu0.shape == (4, 1)


### PR DESCRIPTION
## Summary
- implement `get_tricky_dataloader` synthetic dataset
- expose loader via `crosslearner.datasets`
- document dataset in the manual
- test loader behaviour
- note addition in the changelog

## Testing
- `ruff check .`
- `black --check .`
- `pytest --cov=crosslearner --cov-report=xml -q`


------
https://chatgpt.com/codex/tasks/task_e_685917c5c5ac8324885deae7d1d3830b