### PR TITLE
Document evaluation helpers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   estimation
 - Added propensity head and doubly robust training objective via `delta_prop`
   and `lambda_dr` weights
+- Documented additional evaluation utilities including `policy_risk`,
+  `ate_error`, `att_error`, `bootstrap_ci` and `estimate_propensity`
 - Added optional noise injection and input consistency regularization via
   `noise_std` and `noise_consistency_weight`
 - Added optional representation disentanglement with adversarial training

--- a/docs/usage_examples.rst
+++ b/docs/usage_examples.rst
@@ -78,3 +78,32 @@ Use :func:`crosslearner.export.export_model`:
    export_model(model, x, "acx.pt")           # TorchScript
    export_model(model, x, "acx.onnx", onnx=True)
 
+Additional metrics
+------------------
+
+``crosslearner`` ships several helpers to analyse the quality of treatment
+effect predictions.  After computing ``tau_hat`` you can evaluate policy risk
+and aggregate estimation errors::
+
+   from crosslearner.evaluation import (
+       policy_risk,
+       ate_error,
+       att_error,
+       bootstrap_ci,
+   )
+
+   risk = policy_risk(tau_hat, mu0, mu1)
+   ate_err = ate_error(tau_hat, mu0, mu1)
+   att_err = att_error(tau_hat, mu0, mu1, T)
+   lower, upper = bootstrap_ci(tau_hat)
+
+Propensity estimation
+---------------------
+
+For observational datasets use :func:`crosslearner.evaluation.estimate_propensity`
+to obtain cross-fitted treatment probabilities::
+
+   from crosslearner.evaluation import estimate_propensity
+
+   propensity = estimate_propensity(X, T)
+


### PR DESCRIPTION
## Summary
- expand docs with policy, ATE/ATT error, bootstrap CIs and propensity estimation
- note the new docs in the changelog

## Testing
- `ruff check .`
- `black --check .`
- `pytest --cov=crosslearner --cov-report=xml -q`

------
https://chatgpt.com/codex/tasks/task_e_6859ef6ccc9c8324a99101ee7e959c3e