### PR TITLE
Fix seeding in `train_acx_ensemble`

### DIFF
--- a/crosslearner/training/train_acx.py
+++ b/crosslearner/training/train_acx.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from typing import Optional
+import random
 
 from torch.utils.data import DataLoader
 
@@ -35,14 +36,17 @@ def train_acx_ensemble(
 ) -> list[ACX] | tuple[list[ACX], list[History]]:
     """Train ``n_models`` independent ACX models.
 
-    Each model is trained with the same configuration but with incremented
-    random seeds for reproducibility.
+    Each model is trained with the same configuration.  When ``seed`` is
+    provided, subsequent models are initialised with ``seed + i``.  If ``seed``
+    is ``None``, a random base seed is drawn and incremented so that each model
+    still receives a distinct seed.
     """
 
+    base_seed = seed if seed is not None else random.randrange(2**32)
     models: list[ACX] = []
     histories: list[History] = []
     for i in range(n_models):
-        model_seed = None if seed is None else seed + i
+        model_seed = base_seed + i
         trainer = ACXTrainer(
             model_config,
             training_config,

--- a/tests/test_ensemble.py
+++ b/tests/test_ensemble.py
@@ -33,3 +33,19 @@ def test_predict_tau_ensemble_mean_std():
     mean, std = predict_tau_ensemble([model1, model2], X)
     assert torch.allclose(mean, torch.full((3, 1), 1.5))
     assert torch.allclose(std, torch.full((3, 1), 0.70710677))
+
+
+def test_train_acx_ensemble_seed_none_reproducible():
+    set_seed(0)
+    loader, _ = get_toy_dataloader(batch_size=4, n=16, p=3)
+    model_cfg = ModelConfig(p=3)
+    train_cfg = TrainingConfig(epochs=1)
+    models1 = train_acx_ensemble(loader, model_cfg, train_cfg, n_models=2, device="cpu")
+
+    set_seed(0)
+    loader, _ = get_toy_dataloader(batch_size=4, n=16, p=3)
+    models2 = train_acx_ensemble(loader, model_cfg, train_cfg, n_models=2, device="cpu")
+
+    for m1, m2 in zip(models1, models2):
+        for p1, p2 in zip(m1.parameters(), m2.parameters()):
+            assert torch.allclose(p1, p2)


### PR DESCRIPTION
## Summary
- ensure `train_acx_ensemble` assigns unique seeds even when no seed is provided
- add regression test for reproducibility when `seed=None`

## Testing
- `ruff check .`
- `black --check .`
- `pytest --cov=crosslearner --cov-report=xml -q`

------
https://chatgpt.com/codex/tasks/task_e_685a093a4adc83248d70eca187fa35d0