### PR TITLE
Add categorical embeddings for ACX

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -102,4 +102,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added ``early_stop_metric`` option to ``TrainingConfig`` for choosing the
   validation metric used for early stopping
 - Documented ``pehe`` evaluation helper in usage examples
+- Added optional categorical embeddings via ``cat_dims`` and ``embed_dim`` parameters to ``ACX``
 


### PR DESCRIPTION
## Summary
- extend `ACX` model with optional categorical embeddings
- test the new embedding logic
- document the feature in `CHANGELOG`

## Testing
- `ruff check crosslearner/models/acx.py tests/test_model.py`
- `pytest --cov=crosslearner --cov-report=xml -q`

------
https://chatgpt.com/codex/tasks/task_e_685a863eedfc83249995b7938cd922b2