### PR TITLE
Add missing docstrings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -106,3 +106,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Extended ``ModelConfig`` with ``cat_dims`` and ``embed_dim`` fields and
   enabled representation pretraining with categorical inputs
 
+- Added missing docstrings across several modules to improve code clarity

--- a/crosslearner/benchmarks/run_benchmarks.py
+++ b/crosslearner/benchmarks/run_benchmarks.py
@@ -300,6 +300,7 @@ def _parse_args(include_baselines_flag: bool) -> argparse.Namespace:
 
 
 def main() -> None:
+    """Run benchmarks for the implemented models."""
     args = _parse_args(True)
     run(
         args.dataset,
@@ -310,6 +311,7 @@ def main() -> None:
 
 
 def main_baselines() -> None:
+    """Run the baselines comparison benchmarks."""
     args = _parse_args(False)
     run(args.dataset, args.replicates, args.epochs, baselines=True)
 

--- a/crosslearner/datasets/masked.py
+++ b/crosslearner/datasets/masked.py
@@ -1,3 +1,5 @@
+"""Dataset utilities for random feature masking."""
+
 import torch
 from torch.utils.data import Dataset
 

--- a/crosslearner/datasets/utils.py
+++ b/crosslearner/datasets/utils.py
@@ -1,3 +1,5 @@
+"""Helper functions for downloading datasets."""
+
 import os
 import urllib.request
 

--- a/crosslearner/evaluation/evaluate.py
+++ b/crosslearner/evaluation/evaluate.py
@@ -8,7 +8,6 @@ from crosslearner.utils import model_device
 
 def _model_outputs(model: ACX, X: torch.Tensor) -> tuple[torch.Tensor, ...]:
     """Run ``model`` on ``X`` placed on the correct device."""
-
     device = model_device(model)
     X = X.to(device)
     model.eval()
@@ -18,7 +17,6 @@ def _model_outputs(model: ACX, X: torch.Tensor) -> tuple[torch.Tensor, ...]:
 
 def _predict_tau(model: ACX, X: torch.Tensor) -> torch.Tensor:
     """Return CATE predictions for ``X`` placed on the model's device."""
-
     return _model_outputs(model, X)[2]
 
 
@@ -36,7 +34,6 @@ def evaluate(
     Returns:
         The square-root PEHE value.
     """
-
     device = model_device(model)
     mu0 = mu0.to(device)
     mu1 = mu1.to(device)
@@ -69,7 +66,6 @@ def evaluate_ipw(
     Returns:
         Estimated square-root PEHE using IPW pseudo-outcomes.
     """
-
     device = model_device(model)
     T = T.to(device)
     Y = Y.to(device)
@@ -104,7 +100,6 @@ def evaluate_dr(
     Returns:
         Estimated square-root PEHE using the doubly robust pseudo-outcomes.
     """
-
     device = model_device(model)
     T = T.to(device)
     Y = Y.to(device)

--- a/crosslearner/training/trainer.py
+++ b/crosslearner/training/trainer.py
@@ -23,7 +23,6 @@ from .grl import grad_reverse
 
 def _mmd_rbf(x: torch.Tensor, y: torch.Tensor, sigma: float = 1.0) -> torch.Tensor:
     """Return the (unbiased) RBF Maximum Mean Discrepancy between two samples."""
-
     if x.numel() == 0 or y.numel() == 0:
         return torch.tensor(0.0, device=x.device)
 
@@ -150,7 +149,6 @@ class ACXTrainer:
         self, loader: DataLoader, dataset: Dataset, *, shuffle: bool = True
     ) -> DataLoader:
         """Return a ``DataLoader`` mirroring ``loader`` but with ``dataset``."""
-
         kwargs = dict(
             batch_size=loader.batch_size,
             shuffle=shuffle,
@@ -967,6 +965,7 @@ class ACXTrainer:
         return float(loss_y.item()), float(loss_cons.item()), float(loss_adv.item())
 
     def train(self, loader: DataLoader) -> ACX | Tuple[ACX, History]:
+        """Train the model using ``loader`` and return it when finished."""
         cfg = self.train_cfg
         model = self.model
         eval_model = self.ema_model if self.ema_model is not None else self.model

--- a/crosslearner/utils.py
+++ b/crosslearner/utils.py
@@ -1,3 +1,5 @@
+"""Utility helpers for reproducibility and PyTorch model handling."""
+
 import os
 import random
 
@@ -22,13 +24,11 @@ def set_seed(seed: int, *, deterministic: bool = False) -> None:
 
 def default_device() -> str:
     """Return the best available device string."""
-
     return "cuda" if torch.cuda.is_available() else "cpu"
 
 
 def apply_spectral_norm(model: nn.Module) -> None:
     """Apply spectral normalization to all linear layers in ``model``."""
-
     for module in model.modules():
         if isinstance(module, nn.Linear):
             nn.utils.spectral_norm(module)
@@ -36,7 +36,6 @@ def apply_spectral_norm(model: nn.Module) -> None:
 
 def model_device(model: nn.Module) -> torch.device:
     """Return the device of ``model`` or CPU if no parameters."""
-
     try:
         return next(model.parameters()).device
     except StopIteration:  # pragma: no cover - unlikely

--- a/crosslearner/visualization.py
+++ b/crosslearner/visualization.py
@@ -170,7 +170,6 @@ def plot_cate_calibration(
     tau_hat: torch.Tensor, tau_true: torch.Tensor, bins: int = 10
 ) -> plt.Figure:
     """Return a calibration curve for CATE estimates."""
-
     tau_hat = tau_hat.view(-1)
     tau_true = tau_true.view(-1)
     edges = torch.linspace(tau_hat.min(), tau_hat.max(), bins + 1)
@@ -201,7 +200,6 @@ def plot_partial_dependence(
     grid_points: int = 20,
 ) -> plt.Figure:
     """Return a partial dependence plot for the CATE predictions."""
-
     device = model_device(model)
     X = X.to(device)
     vals = torch.linspace(X[:, feature].min(), X[:, feature].max(), grid_points)
@@ -232,7 +230,6 @@ def plot_ice(
     sample_limit: int | None = None,
 ) -> plt.Figure:
     """Return an Individual Conditional Expectation (ICE) plot for the CATE."""
-
     device = model_device(model)
     X = X.to(device)
     vals = torch.linspace(X[:, feature].min(), X[:, feature].max(), grid_points)
@@ -259,7 +256,6 @@ def plot_ice(
 
 def plot_grad_norms(history: History) -> plt.Figure:
     """Return a matplotlib Figure with gradient norm curves."""
-
     epochs = [h.epoch for h in history]
     fig, ax = plt.subplots()
     if any(h.grad_norm_g is not None for h in history):
@@ -275,7 +271,6 @@ def plot_grad_norms(history: History) -> plt.Figure:
 
 def plot_learning_rates(history: History) -> plt.Figure:
     """Return a matplotlib Figure with learning rate schedules."""
-
     epochs = [h.epoch for h in history]
     fig, ax = plt.subplots()
     if any(h.lr_g is not None for h in history):


### PR DESCRIPTION
## Summary
- document benchmark entry points
- document dataset utils modules
- add module docstring to utilities
- document ACXTrainer's `train` method
- tidy docstring formatting in evaluation and visualization modules
- note improvements in changelog

## Testing
- `ruff check .`
- `black --check .`
- `pytest --cov=crosslearner --cov-report=xml -q`

------
https://chatgpt.com/codex/tasks/task_e_685a91514d7c8324858625d4020d333b