### PR TITLE
Improve docstrings

### DIFF
--- a/crosslearner/datasets/acic2016.py
+++ b/crosslearner/datasets/acic2016.py
@@ -15,7 +15,16 @@ URL_2016 = "https://raw.githubusercontent.com/py-why/BenchmarkDatasets/master/ac
 def get_acic2016_dataloader(
     seed: int = 0, batch_size: int = 256, *, data_dir: str | None = None
 ) -> Tuple[DataLoader, Tuple[torch.Tensor, torch.Tensor]]:
-    """Return ACIC 2016 dataloader for the given replication index."""
+    """Return ACIC 2016 dataloader for the given replication index.
+
+    Args:
+        seed: Replication index from the benchmark dataset.
+        batch_size: Mini-batch size.
+        data_dir: Optional directory to cache the file.
+
+    Returns:
+        Tuple ``(loader, (mu0, mu1))`` with the dataloader and counterfactuals.
+    """
     data_dir = data_dir or os.path.join(os.path.dirname(__file__), "_data")
     os.makedirs(data_dir, exist_ok=True)
     fpath = download_if_missing(URL_2016, os.path.join(data_dir, "acic2016.npz"))

--- a/crosslearner/datasets/acic2018.py
+++ b/crosslearner/datasets/acic2018.py
@@ -15,7 +15,16 @@ URL_2018 = "https://raw.githubusercontent.com/py-why/BenchmarkDatasets/master/ac
 def get_acic2018_dataloader(
     seed: int = 0, batch_size: int = 256, *, data_dir: str | None = None
 ) -> Tuple[DataLoader, Tuple[torch.Tensor, torch.Tensor]]:
-    """Return ACIC 2018 dataloader for the given replication index."""
+    """Return ACIC 2018 dataloader for the given replication index.
+
+    Args:
+        seed: Replication index from the benchmark dataset.
+        batch_size: Mini-batch size.
+        data_dir: Optional directory to cache the file.
+
+    Returns:
+        Tuple ``(loader, (mu0, mu1))`` with dataloader and counterfactuals.
+    """
     data_dir = data_dir or os.path.join(os.path.dirname(__file__), "_data")
     os.makedirs(data_dir, exist_ok=True)
     fpath = download_if_missing(URL_2018, os.path.join(data_dir, "acic2018.npz"))

--- a/crosslearner/datasets/synthetic.py
+++ b/crosslearner/datasets/synthetic.py
@@ -11,7 +11,19 @@ def get_confounding_dataloader(
     confounding: float = 0.0,
     seed: int | None = None,
 ):
-    """Return synthetic dataloader with adjustable confounding strength."""
+    """Return synthetic dataloader with adjustable confounding strength.
+
+    Args:
+        batch_size: Size of each mini-batch.
+        n: Number of samples to generate.
+        p: Number of covariates.
+        confounding: Strength of the unobserved confounder.
+        seed: Optional random seed for reproducibility.
+
+    Returns:
+        Tuple ``(loader, (mu0, mu1))`` with the ``DataLoader`` and true
+        potential outcomes.
+    """
     gen = torch.Generator().manual_seed(seed) if seed is not None else None
     X = torch.randn(n, p, generator=gen)
     U = torch.randn(n, generator=gen)

--- a/crosslearner/datasets/utils.py
+++ b/crosslearner/datasets/utils.py
@@ -7,8 +7,15 @@ import urllib.request
 def download_if_missing(url: str, path: str) -> str:
     """Download ``url`` to ``path`` if the file does not already exist.
 
-    Raises a ``RuntimeError`` when the download fails so users can fetch the
-    file manually.
+    Args:
+        url: Remote location to download.
+        path: Destination file path.
+
+    Returns:
+        Local path to the downloaded file.
+
+    Raises:
+        RuntimeError: If the download fails.
     """
     if os.path.exists(path):
         return path

--- a/crosslearner/evaluation/metrics.py
+++ b/crosslearner/evaluation/metrics.py
@@ -22,8 +22,13 @@ def pehe(tau_hat: torch.Tensor, tau_true: torch.Tensor) -> float:
 def policy_risk(tau_hat: torch.Tensor, mu0: torch.Tensor, mu1: torch.Tensor) -> float:
     """Return the policy risk of using ``tau_hat`` for treatment decisions.
 
-    The function compares the outcome under the policy implied by ``tau_hat``
-    against always choosing the best potential outcome.
+    Args:
+        tau_hat: Predicted treatment effects.
+        mu0: Potential outcome under control.
+        mu1: Potential outcome under treatment.
+
+    Returns:
+        Expected regret of the policy implied by ``tau_hat``.
     """
 
     opt_outcome = torch.max(mu0, mu1)
@@ -33,7 +38,16 @@ def policy_risk(tau_hat: torch.Tensor, mu0: torch.Tensor, mu1: torch.Tensor) -> 
 
 
 def ate_error(tau_hat: torch.Tensor, mu0: torch.Tensor, mu1: torch.Tensor) -> float:
-    """Return estimation error for the Average Treatment Effect (ATE)."""
+    """Return estimation error for the Average Treatment Effect (ATE).
+
+    Args:
+        tau_hat: Predicted treatment effects.
+        mu0: Potential outcome under control.
+        mu1: Potential outcome under treatment.
+
+    Returns:
+        Difference between estimated and true ATE.
+    """
 
     ate_hat = torch.mean(tau_hat)
     ate_true = torch.mean(mu1 - mu0)
@@ -43,7 +57,17 @@ def ate_error(tau_hat: torch.Tensor, mu0: torch.Tensor, mu1: torch.Tensor) -> fl
 def att_error(
     tau_hat: torch.Tensor, mu0: torch.Tensor, mu1: torch.Tensor, t: torch.Tensor
 ) -> float:
-    """Return estimation error for the ATT (Average Treatment effect on Treated)."""
+    """Return estimation error for the ATT (Average Treatment effect on Treated).
+
+    Args:
+        tau_hat: Predicted treatment effects.
+        mu0: Potential outcome under control.
+        mu1: Potential outcome under treatment.
+        t: Binary treatment assignments.
+
+    Returns:
+        Difference between estimated and true ATT.
+    """
 
     mask = t.view(-1).bool()
     att_hat = torch.mean(tau_hat.view(-1)[mask])
@@ -54,7 +78,16 @@ def att_error(
 def bootstrap_ci(
     values: torch.Tensor, *, level: float = 0.95, n_boot: int = 1000
 ) -> tuple[float, float]:
-    """Return a bootstrap confidence interval for the mean of ``values``."""
+    """Return a bootstrap confidence interval for the mean of ``values``.
+
+    Args:
+        values: Sample of values to average.
+        level: Confidence level of the interval.
+        n_boot: Number of bootstrap replicates.
+
+    Returns:
+        Tuple ``(lower, upper)`` bounds of the confidence interval.
+    """
 
     arr = values.view(-1).cpu().numpy()
     samples = np.random.choice(arr, size=(n_boot, arr.size), replace=True)

--- a/crosslearner/evaluation/uncertainty.py
+++ b/crosslearner/evaluation/uncertainty.py
@@ -16,10 +16,13 @@ def predict_tau_mc_dropout(
 ) -> Tuple[torch.Tensor, torch.Tensor]:
     """Return mean and standard deviation of MC dropout predictions.
 
-    The model is temporarily set to training mode so that dropout layers
-    remain active during the forward passes. Predictions are collected over
-    ``passes`` runs and aggregated to obtain an approximate posterior
-    mean and standard deviation for the treatment effect.
+    Args:
+        model: Trained ``ACX`` model with dropout layers.
+        X: Input covariates ``(n, p)``.
+        passes: Number of stochastic forward passes.
+
+    Returns:
+        Tuple ``(mean, std)`` with aggregated predictions.
     """
 
     device = model_device(model)
@@ -40,7 +43,15 @@ def predict_tau_mc_dropout(
 def predict_tau_ensemble(
     models: Tuple[ACX, ...] | list[ACX], X: torch.Tensor
 ) -> Tuple[torch.Tensor, torch.Tensor]:
-    """Return mean and standard deviation of ensemble CATE predictions."""
+    """Return mean and standard deviation of ensemble CATE predictions.
+
+    Args:
+        models: Sequence of trained ``ACX`` models.
+        X: Covariates ``(n, p)`` used for prediction.
+
+    Returns:
+        Tuple ``(mean, std)`` over the ensemble predictions.
+    """
 
     samples = []
     for model in models:

--- a/crosslearner/models/acx.py
+++ b/crosslearner/models/acx.py
@@ -8,10 +8,15 @@ from typing import Callable, Iterable
 def _get_activation(act: str | Callable[[], nn.Module]) -> Callable[[], nn.Module]:
     """Return an activation constructor from string or callable.
 
-    The function accepts either a string identifier or a callable returning a
-    fresh ``nn.Module`` instance.  Passing an ``nn.Module`` instance is a common
-    mistake that leads to cryptic runtime errors, therefore it is explicitly
-    disallowed.
+    Args:
+        act: Name of the activation or a callable returning a module.
+
+    Returns:
+        A callable that creates a new activation module.
+
+    Raises:
+        TypeError: If ``act`` is not a string or callable.
+        ValueError: If ``act`` is an unknown string identifier.
     """
 
     if isinstance(act, str):

--- a/crosslearner/training/grl.py
+++ b/crosslearner/training/grl.py
@@ -8,17 +8,42 @@ class GradReverse(torch.autograd.Function):
 
     @staticmethod
     def forward(ctx, x, lambd):
-        """Forward pass that stores ``lambd`` for the backward step."""
+        """Forward pass that stores ``lambd`` for the backward step.
+
+        Args:
+            ctx: Autograd context provided by PyTorch.
+            x: Input tensor.
+            lambd: Scaling factor for the reversed gradient.
+
+        Returns:
+            The input ``x`` unchanged.
+        """
         ctx.lambd = lambd
         return x.view_as(x)
 
     @staticmethod
     def backward(ctx, grad_output):
-        """Reverse the gradient multiplied by ``lambd``."""
+        """Reverse the gradient multiplied by ``lambd``.
+
+        Args:
+            ctx: Autograd context with ``lambd`` saved from ``forward``.
+            grad_output: Upstream gradient tensor.
+
+        Returns:
+            Tuple containing the modified gradient and ``None`` for ``lambd``.
+        """
         return grad_output.neg() * ctx.lambd, None
 
 
 def grad_reverse(x, lambd=1.0):
-    """Convenience wrapper for the gradient reversal function."""
+    """Convenience wrapper for the gradient reversal function.
+
+    Args:
+        x: Input tensor.
+        lambd: Scaling factor for the reversed gradient.
+
+    Returns:
+        ``x`` as a gradient-reversing autograd variable.
+    """
 
     return GradReverse.apply(x, lambd)

--- a/crosslearner/training/nuisance.py
+++ b/crosslearner/training/nuisance.py
@@ -10,7 +10,15 @@ from crosslearner.utils import set_seed
 
 
 def _make_regressor(inp: int, hid: Iterable[int] = (64, 64)) -> nn.Sequential:
-    """Return a simple fully connected regressor."""
+    """Return a simple fully connected regressor.
+
+    Args:
+        inp: Input dimension.
+        hid: Sizes of hidden layers.
+
+    Returns:
+        A sequential ``nn.Module`` implementing the regressor.
+    """
     layers: list[nn.Module] = []
     d = inp
     for h in hid:
@@ -21,7 +29,15 @@ def _make_regressor(inp: int, hid: Iterable[int] = (64, 64)) -> nn.Sequential:
 
 
 def _make_propensity_net(inp: int, hid: Iterable[int] = (64, 64)) -> nn.Sequential:
-    """Return a sigmoid-activated regressor for propensity scores."""
+    """Return a sigmoid-activated regressor for propensity scores.
+
+    Args:
+        inp: Input dimension.
+        hid: Sizes of hidden layers.
+
+    Returns:
+        A sequential network ending with a sigmoid layer.
+    """
     net = _make_regressor(inp, hid)
     net.add_module("sigmoid", nn.Sigmoid())
     return net
@@ -41,7 +57,24 @@ def estimate_nuisances(
     device: str,
     seed: int = 0,
 ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
-    """Return cross-fitted propensity and outcome predictions."""
+    """Return cross-fitted propensity and outcome predictions.
+
+    Args:
+        X: Covariate matrix ``(n, p)``.
+        T: Treatment indicators ``(n, 1)`` or ``(n,)``.
+        Y: Observed outcomes ``(n, 1)``.
+        folds: Number of cross-fitting folds.
+        lr: Learning rate for all networks.
+        batch: Mini-batch size.
+        propensity_epochs: Training epochs for the propensity model.
+        outcome_epochs: Training epochs for the outcome models.
+        early_stop: Patience for early stopping.
+        device: Device on which to train the networks.
+        seed: Random seed for reproducibility.
+
+    Returns:
+        Tuple ``(e_hat, mu0_hat, mu1_hat)`` with cross-fitted predictions.
+    """
     bce = nn.BCELoss()
     mse = nn.MSELoss()
 

--- a/crosslearner/training/train_acx.py
+++ b/crosslearner/training/train_acx.py
@@ -19,7 +19,19 @@ def train_acx(
     device: Optional[str] = None,
     seed: int | None = None,
 ) -> ACX | tuple[ACX, History]:
-    """Train an ACX model using configuration objects."""
+    """Train an ACX model using configuration objects.
+
+    Args:
+        loader: Training data loader.
+        model_config: Configuration for the ``ACX`` architecture.
+        training_config: Hyperparameters controlling training.
+        device: Optional device string.
+        seed: Optional random seed.
+
+    Returns:
+        The trained model or ``(model, history)`` when ``return_history`` is
+        enabled.
+    """
 
     trainer = ACXTrainer(model_config, training_config, device=device, seed=seed)
     return trainer.train(loader)
@@ -36,10 +48,21 @@ def train_acx_ensemble(
 ) -> list[ACX] | tuple[list[ACX], list[History]]:
     """Train ``n_models`` independent ACX models.
 
-    Each model is trained with the same configuration.  When ``seed`` is
-    provided, subsequent models are initialised with ``seed + i``.  If ``seed``
+    Args:
+        loader: Training data loader.
+        model_config: Configuration for the ``ACX`` architecture.
+        training_config: Hyperparameters controlling training.
+        n_models: Number of models to train.
+        device: Optional device string.
+        seed: Optional base random seed. Different seeds are derived from it.
+
+    Returns:
+        List of trained models or additionally their histories when requested.
+
+    Each model is trained with the same configuration. When ``seed`` is
+    provided, subsequent models are initialised with ``seed + i``. If ``seed``
     is ``None``, a random base seed is drawn and incremented so that each model
-    still receives a distinct seed.
+    receives a distinct seed.
     """
 
     base_seed = seed if seed is not None else random.randrange(2**32)

--- a/crosslearner/training/trainer.py
+++ b/crosslearner/training/trainer.py
@@ -22,7 +22,16 @@ from .grl import grad_reverse
 
 
 def _mmd_rbf(x: torch.Tensor, y: torch.Tensor, sigma: float = 1.0) -> torch.Tensor:
-    """Return the (unbiased) RBF Maximum Mean Discrepancy between two samples."""
+    """Return the (unbiased) RBF Maximum Mean Discrepancy between two samples.
+
+    Args:
+        x: First sample ``(n_x, d)``.
+        y: Second sample ``(n_y, d)``.
+        sigma: Bandwidth of the RBF kernel.
+
+    Returns:
+        Scalar tensor with the unbiased MMD estimate.
+    """
     if x.numel() == 0 or y.numel() == 0:
         return torch.tensor(0.0, device=x.device)
 
@@ -148,7 +157,16 @@ class ACXTrainer:
     def _clone_loader(
         self, loader: DataLoader, dataset: Dataset, *, shuffle: bool = True
     ) -> DataLoader:
-        """Return a ``DataLoader`` mirroring ``loader`` but with ``dataset``."""
+        """Return a ``DataLoader`` mirroring ``loader`` but with ``dataset``.
+
+        Args:
+            loader: Existing dataloader to copy settings from.
+            dataset: Replacement dataset.
+            shuffle: Whether to shuffle the new loader.
+
+        Returns:
+            A new ``DataLoader`` configured like ``loader``.
+        """
         kwargs = dict(
             batch_size=loader.batch_size,
             shuffle=shuffle,
@@ -175,7 +193,14 @@ class ACXTrainer:
         return DataLoader(dataset, **kwargs)
 
     def _pretrain_representation(self, loader: DataLoader) -> None:
-        """Warm-up the encoder by reconstructing masked inputs."""
+        """Warm-up the encoder by reconstructing masked inputs.
+
+        Args:
+            loader: Data loader providing the training data.
+
+        Returns:
+            ``None``. The model weights are updated in-place.
+        """
         cfg = self.train_cfg
         if cfg.pretrain_epochs <= 0:
             return
@@ -235,6 +260,16 @@ class ACXTrainer:
     def _pack_inputs(
         self, h: torch.Tensor, y: torch.Tensor, t: torch.Tensor
     ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        """Concatenate inputs for the discriminator if ``disc_pack`` > 1.
+
+        Args:
+            h: Representation tensor from ``phi``.
+            y: Outcome tensor.
+            t: Treatment tensor.
+
+        Returns:
+            Packed versions of ``(h, y, t)``.
+        """
         pack = max(1, int(self.model_cfg.disc_pack))
         if pack <= 1:
             return h, y, t
@@ -245,7 +280,14 @@ class ACXTrainer:
         return h, y, t
 
     def _sample_negatives(self, t: torch.Tensor) -> torch.Tensor:
-        """Return indices of negative samples from the opposite treatment group."""
+        """Return indices of negative samples from the opposite treatment group.
+
+        Args:
+            t: Binary treatment indicators ``(n,)``.
+
+        Returns:
+            Indices of samples with the opposite treatment for each element.
+        """
         t = t.view(-1)
         n = t.size(0)
         idx0 = torch.where(t == 0)[0]

--- a/crosslearner/utils.py
+++ b/crosslearner/utils.py
@@ -9,7 +9,15 @@ import torch.nn as nn
 
 
 def set_seed(seed: int, *, deterministic: bool = False) -> None:
-    """Set random seed for Python, NumPy and PyTorch."""
+    """Set random seed for Python, NumPy and PyTorch.
+
+    Args:
+        seed: Seed value used for all RNGs.
+        deterministic: If ``True`` enable deterministic CUDA operations.
+
+    Returns:
+        ``None``. The global random state is modified in-place.
+    """
     random.seed(seed)
     np.random.seed(seed)
     torch.manual_seed(seed)
@@ -23,19 +31,37 @@ def set_seed(seed: int, *, deterministic: bool = False) -> None:
 
 
 def default_device() -> str:
-    """Return the best available device string."""
+    """Return the best available device string.
+
+    Returns:
+        ``"cuda"`` when a GPU is available, otherwise ``"cpu"``.
+    """
     return "cuda" if torch.cuda.is_available() else "cpu"
 
 
 def apply_spectral_norm(model: nn.Module) -> None:
-    """Apply spectral normalization to all linear layers in ``model``."""
+    """Apply spectral normalization to all linear layers in ``model``.
+
+    Args:
+        model: Module whose ``nn.Linear`` layers should be normalised.
+
+    Returns:
+        ``None``. ``model`` is modified in-place.
+    """
     for module in model.modules():
         if isinstance(module, nn.Linear):
             nn.utils.spectral_norm(module)
 
 
 def model_device(model: nn.Module) -> torch.device:
-    """Return the device of ``model`` or CPU if no parameters."""
+    """Return the device of ``model`` or CPU if no parameters.
+
+    Args:
+        model: Neural network whose parameter device should be inspected.
+
+    Returns:
+        Device of the first parameter or ``cpu`` when the model has none.
+    """
     try:
         return next(model.parameters()).device
     except StopIteration:  # pragma: no cover - unlikely


### PR DESCRIPTION
## Summary
- expand docstrings with args/returns across utilities and datasets
- document uncertainty helpers
- add docs for metrics and nuisance models
- clarify trainer and training helpers

## Testing
- `ruff check .`
- `black --check .`
- `pytest --cov=crosslearner --cov-report=xml -q`

------
https://chatgpt.com/codex/tasks/task_e_685b0dc4604c832485865a059e7c0732