### PR TITLE
Add random DAG data generator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- Added `get_random_dag_dataloader` for generating random DAG-based synthetic datasets
 - Initial creation of CHANGELOG
 - Added `crosslearner-benchmark` command comparing ACX to baseline models
 - Added PacGAN-style discriminator packing via `disc_pack` configuration

--- a/crosslearner/datasets/__init__.py
+++ b/crosslearner/datasets/__init__.py
@@ -5,6 +5,7 @@ from .complex import get_complex_dataloader
 from .synthetic import get_confounding_dataloader
 from .aircraft import get_aircraft_dataloader
 from .tricks import get_tricky_dataloader
+from .random_dag import get_random_dag_dataloader
 from .masked import MaskedFeatureDataset
 
 
@@ -62,5 +63,6 @@ __all__ = [
     "get_confounding_dataloader",
     "get_aircraft_dataloader",
     "get_tricky_dataloader",
+    "get_random_dag_dataloader",
     "MaskedFeatureDataset",
 ]

--- a/crosslearner/datasets/random_dag.py
+++ b/crosslearner/datasets/random_dag.py
@@ -1,0 +1,99 @@
+"""Random DAG-based synthetic dataset generator."""
+
+from __future__ import annotations
+import random
+from typing import Callable
+
+import torch
+from torch.utils.data import DataLoader, TensorDataset
+
+
+_Function = Callable[[torch.Tensor], torch.Tensor]
+
+
+_FUNCTIONS: list[_Function] = [
+    lambda x: x,
+    torch.tanh,
+    torch.sin,
+    lambda x: x**2,
+]
+
+
+_DISTROS = ["normal", "uniform", "exponential"]
+
+
+def _sample_distribution(
+    name: str, n: int, gen: torch.Generator | None
+) -> torch.Tensor:
+    if name == "normal":
+        return torch.randn(n, generator=gen)
+    if name == "uniform":
+        return 2 * torch.rand(n, generator=gen) - 1
+    if name == "exponential":
+        r = torch.rand(n, generator=gen)
+        return -torch.log1p(-r)
+    raise ValueError(f"unknown distribution {name}")
+
+
+def get_random_dag_dataloader(
+    batch_size: int = 256,
+    n: int = 8000,
+    p: int = 10,
+    seed: int | None = None,
+) -> tuple[DataLoader, tuple[torch.Tensor, torch.Tensor]]:
+    """Return DataLoader for a random acyclic structural equation model."""
+    gen = torch.Generator().manual_seed(seed) if seed is not None else None
+    if seed is not None:
+        random.seed(seed)
+
+    order = list(range(p))
+    random.shuffle(order)
+    X: list[torch.Tensor] = [torch.zeros(n) for _ in range(p)]
+    for idx, j in enumerate(order):
+        dist = random.choice(_DISTROS)
+        x = _sample_distribution(dist, n, gen)
+        for i in order[:idx]:
+            if torch.rand(1, generator=gen).item() < 0.3:
+                func = random.choice(_FUNCTIONS)
+                bias = 0.1 * torch.randn(1, generator=gen)
+                weight = torch.randn(1, generator=gen)
+                x = x + weight * func(X[i] + bias)
+        X[j] = x
+    X_tensor = torch.stack(X, dim=1)
+
+    # Treatment model
+    logit = 0.1 * torch.randn(1, generator=gen)
+    for j in range(p):
+        if torch.rand(1, generator=gen).item() < 0.5:
+            func = random.choice(_FUNCTIONS)
+            bias = 0.1 * torch.randn(1, generator=gen)
+            weight = torch.randn(1, generator=gen)
+            logit = logit + weight * func(X[j] + bias)
+    pi = torch.sigmoid(logit)
+    T = torch.bernoulli(pi, generator=gen).float()
+
+    # Outcome model
+    base = 0.1 * torch.randn(1, generator=gen)
+    for j in range(p):
+        if torch.rand(1, generator=gen).item() < 0.5:
+            func = random.choice(_FUNCTIONS)
+            bias = 0.1 * torch.randn(1, generator=gen)
+            weight = torch.randn(1, generator=gen)
+            base = base + weight * func(X[j] + bias)
+
+    func_ty = random.choice(_FUNCTIONS)
+    bias_ty = 0.1 * torch.randn(1, generator=gen)
+    weight_ty = torch.randn(1, generator=gen)
+
+    mu0_val = base + weight_ty * func_ty(torch.zeros_like(T) + bias_ty)
+    mu1_val = base + weight_ty * func_ty(torch.ones_like(T) + bias_ty)
+
+    Y = torch.where(T.bool(), mu1_val, mu0_val)
+    Y = Y + 0.1 * torch.randn(n, generator=gen)
+
+    loader = DataLoader(
+        TensorDataset(X_tensor, T.unsqueeze(-1), Y.unsqueeze(-1)),
+        batch_size=batch_size,
+        shuffle=True,
+    )
+    return loader, (mu0_val.unsqueeze(-1), mu1_val.unsqueeze(-1))

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -4,6 +4,7 @@ from crosslearner.datasets.complex import get_complex_dataloader
 from crosslearner.datasets.jobs import get_jobs_dataloader
 from crosslearner.datasets.aircraft import get_aircraft_dataloader
 from crosslearner.datasets.tricks import get_tricky_dataloader
+from crosslearner.datasets.random_dag import get_random_dag_dataloader
 from crosslearner.datasets import ihdp, acic2016, acic2018, twins, lalonde, synthetic
 
 
@@ -165,6 +166,16 @@ def test_get_tricky_dataloader():
     loader, (mu0, mu1) = get_tricky_dataloader(batch_size=2, n=4, p=4, seed=0)
     X, T, Y = next(iter(loader))
     assert X.shape == (2, 4)
+    assert T.shape == (2, 1)
+    assert Y.shape == (2, 1)
+    assert mu0.shape == (4, 1)
+    assert mu1.shape == (4, 1)
+
+
+def test_get_random_dag_dataloader():
+    loader, (mu0, mu1) = get_random_dag_dataloader(batch_size=2, n=4, p=3, seed=0)
+    X, T, Y = next(iter(loader))
+    assert X.shape == (2, 3)
     assert T.shape == (2, 1)
     assert Y.shape == (2, 1)
     assert mu0.shape == (4, 1)

--- a/tests/test_random_dag_dataset.py
+++ b/tests/test_random_dag_dataset.py
@@ -1,0 +1,9 @@
+import torch
+from crosslearner.datasets.random_dag import get_random_dag_dataloader
+
+
+def test_get_random_dag_dataloader_seed_reproducible():
+    _, (mu0_a, mu1_a) = get_random_dag_dataloader(batch_size=2, n=4, p=3, seed=0)
+    _, (mu0_b, mu1_b) = get_random_dag_dataloader(batch_size=2, n=4, p=3, seed=0)
+    assert torch.allclose(mu0_a, mu0_b)
+    assert torch.allclose(mu1_a, mu1_b)


### PR DESCRIPTION
## Summary
- implement a random DAG-based dataset generator
- expose `get_random_dag_dataloader`
- test dataset shapes and reproducibility

## Testing
- `ruff check .`
- `black --check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685b1320bd648324aa3931b4605d2969