### PR TITLE
Add pretraining loss console output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -109,3 +109,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Added missing docstrings across several modules to improve code clarity
 - Improved adaptive batch scheduler with unified autocast and new unit tests
+- Logged reconstruction loss during representation pretraining

--- a/crosslearner/training/trainer.py
+++ b/crosslearner/training/trainer.py
@@ -271,7 +271,9 @@ class ACXTrainer:
         mse = nn.MSELoss()
         was_training = self.model.training
         self.model.train()
-        for _ in range(cfg.pretrain_epochs):
+        for epoch in range(cfg.pretrain_epochs):
+            loss_sum = 0.0
+            batch_count = 0
             for batch in pre_loader:
                 if len(batch) == 3:
                     x_m, x_cat, x = batch
@@ -287,6 +289,14 @@ class ACXTrainer:
                 opt.zero_grad(set_to_none=True)
                 loss.backward()
                 opt.step()
+                loss_sum += loss.item()
+                batch_count += 1
+            if cfg.verbose:
+                mean_loss = loss_sum / max(1, batch_count)
+                print(
+                    f"pretrain epoch {epoch + 1}/{cfg.pretrain_epochs} "
+                    f"recon_loss={mean_loss:.4f}"
+                )
         cfg.lr_g = cfg.finetune_lr or cfg.lr_g * 0.1
         if not was_training:
             self.model.eval()

--- a/docs/representation_pretraining.rst
+++ b/docs/representation_pretraining.rst
@@ -7,6 +7,9 @@ corrupted inputs from :class:`crosslearner.datasets.MaskedFeatureDataset` and a
 linear decoder tries to predict the original features.  Only the shared
 representation network ``phi`` and this decoder are updated.
 
+When ``verbose`` is enabled the average reconstruction loss for each
+pretraining epoch is printed to the console.
+
 ``pretrain_mask_prob`` controls the fraction of features set to zero, mimicking
 missing covariates.  ``pretrain_lr`` can override the encoder's learning rate
 for this phase while ``finetune_lr`` specifies the learning rate for subsequent


### PR DESCRIPTION
## Summary
- display reconstruction loss for each pretraining epoch
- document the pretraining log output
- mention the change in the changelog

## Testing
- `ruff check .`
- `black --check crosslearner/training/trainer.py`
- `pytest --cov=crosslearner --cov-report=xml -q`

------
https://chatgpt.com/codex/tasks/task_e_685d243ecbd48324ab357e4c267df603