### PR TITLE
Add progress bar logging to training

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -110,3 +110,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added missing docstrings across several modules to improve code clarity
 - Improved adaptive batch scheduler with unified autocast and new unit tests
 - Logged reconstruction loss during representation pretraining
+- Logged batch progress with a progress bar when ``verbose`` is enabled during
+  training

--- a/crosslearner/training/trainer.py
+++ b/crosslearner/training/trainer.py
@@ -16,6 +16,7 @@ from torch.utils.data import (
     SequentialSampler,
 )
 from torch.utils.tensorboard import SummaryWriter
+from tqdm.auto import tqdm
 
 from .config import ModelConfig, TrainingConfig
 from .history import EpochStats, History
@@ -274,7 +275,14 @@ class ACXTrainer:
         for epoch in range(cfg.pretrain_epochs):
             loss_sum = 0.0
             batch_count = 0
-            for batch in pre_loader:
+            batch_iter = pre_loader
+            if cfg.verbose:
+                batch_iter = tqdm(
+                    pre_loader,
+                    desc=f"pretrain {epoch + 1}/{cfg.pretrain_epochs}",
+                    leave=False,
+                )
+            for batch in batch_iter:
                 if len(batch) == 3:
                     x_m, x_cat, x = batch
                     x_cat = x_cat.to(self.device)
@@ -669,7 +677,15 @@ class ACXTrainer:
         }
         rep_counts = {0: 0, 1: 0}
 
-        for batch in loader:
+        batch_iter = loader
+        if cfg.verbose:
+            batch_iter = tqdm(
+                loader,
+                desc=f"epoch {epoch+1}/{cfg.epochs}",
+                leave=False,
+            )
+
+        for batch in batch_iter:
             if len(batch) == 4:
                 Xb, Xcb, Tb, Yb = batch
                 Xcb = Xcb.to(device)

--- a/docs/representation_pretraining.rst
+++ b/docs/representation_pretraining.rst
@@ -7,8 +7,8 @@ corrupted inputs from :class:`crosslearner.datasets.MaskedFeatureDataset` and a
 linear decoder tries to predict the original features.  Only the shared
 representation network ``phi`` and this decoder are updated.
 
-When ``verbose`` is enabled the average reconstruction loss for each
-pretraining epoch is printed to the console.
+When ``verbose`` is enabled a progress bar tracks batches and the average
+reconstruction loss for each pretraining epoch is printed to the console.
 
 ``pretrain_mask_prob`` controls the fraction of features set to zero, mimicking
 missing covariates.  ``pretrain_lr`` can override the encoder's learning rate

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ dependencies = [
     "optuna",
     "onnx",
     "onnxruntime",
+    "tqdm",
 ]
 
 [project.scripts]

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,4 @@ optuna
 onnx
 onnxruntime
 furo
+tqdm


### PR DESCRIPTION
## Summary
- show batch progress with tqdm during pretraining and main training
- document progress bar logging in pretraining docs
- list tqdm dependency
- update changelog

## Testing
- `ruff check .`
- `black --check .`
- `pytest --cov=crosslearner --cov-report=xml -q`

------
https://chatgpt.com/codex/tasks/task_e_685d26ce793c83248d8226c4d320b36b