### PR TITLE
Add validation loss plotting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- Extended ``plot_losses`` to visualise validation losses and identify risk-based metrics
 - Added `get_random_dag_dataloader` for generating random DAG-based synthetic datasets
 - Initial creation of CHANGELOG
 - Added `crosslearner-benchmark` command comparing ACX to baseline models

--- a/crosslearner/visualization.py
+++ b/crosslearner/visualization.py
@@ -26,16 +26,57 @@ def plot_losses(history: History):
     ax1.plot(epochs, [h.loss_adv for h in history], label="adversarial")
     ax1.set_xlabel("epoch")
     ax1.set_ylabel("loss")
-    has_val = any(h.val_pehe is not None for h in history)
-    if has_val:
+    has_metric = any(h.val_pehe is not None for h in history)
+    has_val_losses = any(
+        h.val_loss_y is not None
+        or h.val_loss_cons is not None
+        or h.val_loss_adv is not None
+        for h in history
+    )
+
+    prefix = "val" if has_metric else "risk"
+
+    if has_val_losses:
+        if any(h.val_loss_y is not None for h in history):
+            ax1.plot(
+                epochs,
+                [
+                    h.val_loss_y if h.val_loss_y is not None else float("nan")
+                    for h in history
+                ],
+                "C0--",
+                label=f"{prefix}_loss_y",
+            )
+        if any(h.val_loss_cons is not None for h in history):
+            ax1.plot(
+                epochs,
+                [
+                    h.val_loss_cons if h.val_loss_cons is not None else float("nan")
+                    for h in history
+                ],
+                "C1--",
+                label=f"{prefix}_loss_cons",
+            )
+        if any(h.val_loss_adv is not None for h in history):
+            ax1.plot(
+                epochs,
+                [
+                    h.val_loss_adv if h.val_loss_adv is not None else float("nan")
+                    for h in history
+                ],
+                "C2--",
+                label=f"{prefix}_loss_adv",
+            )
+
+    if has_metric:
         ax2 = ax1.twinx()
         ax2.plot(
             epochs,
             [h.val_pehe if h.val_pehe is not None else float("nan") for h in history],
             "k--",
-            label="val_pehe",
+            label="val_pehe" if prefix == "val" else "val_risk",
         )
-        ax2.set_ylabel("PEHE")
+        ax2.set_ylabel("PEHE" if prefix == "val" else "risk")
         lines1, labels1 = ax1.get_legend_handles_labels()
         lines2, labels2 = ax2.get_legend_handles_labels()
         ax2.legend(lines1 + lines2, labels1 + labels2)

--- a/tests/test_visualization.py
+++ b/tests/test_visualization.py
@@ -32,6 +32,45 @@ def test_plot_losses_returns_figure():
     matplotlib.pyplot.close(fig)
 
 
+def test_plot_losses_with_validation_losses():
+    hist = [
+        EpochStats(
+            epoch=0,
+            loss_d=0.0,
+            loss_g=0.0,
+            loss_y=0.0,
+            loss_cons=0.0,
+            loss_adv=0.0,
+            val_pehe=1.0,
+            val_loss_y=0.1,
+            val_loss_cons=0.2,
+            val_loss_adv=0.3,
+        )
+    ]
+    fig = plot_losses(hist)
+    assert fig is not None
+    matplotlib.pyplot.close(fig)
+
+
+def test_plot_losses_with_risk_only():
+    hist = [
+        EpochStats(
+            epoch=0,
+            loss_d=0.0,
+            loss_g=0.0,
+            loss_y=0.0,
+            loss_cons=0.0,
+            loss_adv=0.0,
+            val_loss_y=0.1,
+            val_loss_cons=0.2,
+            val_loss_adv=0.3,
+        )
+    ]
+    fig = plot_losses(hist)
+    assert fig is not None
+    matplotlib.pyplot.close(fig)
+
+
 def test_scatter_tau_returns_figure():
     model = ACX(p=3)
     X = torch.randn(4, 3)


### PR DESCRIPTION
## Summary
- plot validation outcome/consistency/adversarial losses when available
- label risk-based metrics when no validation data is used
- test plotting with validation and risk losses
- document enhancement in changelog

## Testing
- `ruff check .`
- `black --check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685d2ad28fb08324ae101ff48546cc2d