### PR TITLE
Default adaptive batch max to dataset size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -116,3 +116,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Logged reconstruction loss during representation pretraining
 - Logged batch progress with a progress bar when ``verbose`` is enabled during
   training
+- ``gns_max_batch`` now defaults to the dataset size when using adaptive
+  batching

--- a/crosslearner/training/config.py
+++ b/crosslearner/training/config.py
@@ -229,4 +229,5 @@ class TrainingConfig:
     gns_max_batch: Optional[int] = (
         None
         #: Optional hard limit on the batch size reached by the scheduler.
+        #: ``None`` defaults to the full dataset size.
     )

--- a/crosslearner/training/trainer.py
+++ b/crosslearner/training/trainer.py
@@ -1132,6 +1132,11 @@ class ACXTrainer:
         opt_g, opt_d = self._make_optimizers()
         sched_g, sched_d = self._make_schedulers(opt_g, opt_d)
         if cfg.adaptive_batch:
+            max_B = (
+                cfg.gns_max_batch
+                if cfg.gns_max_batch is not None
+                else len(loader.dataset)
+            )
             self.scheduler = GNSBatchScheduler(
                 model,
                 self._scheduler_loss,
@@ -1143,7 +1148,7 @@ class ACXTrainer:
                 check_every=cfg.gns_check_every,
                 plateau_patience=cfg.gns_plateau_patience,
                 ema=cfg.gns_ema,
-                max_global_batch=cfg.gns_max_batch,
+                max_global_batch=max_B,
             )
 
         bce = nn.BCEWithLogitsLoss()

--- a/crosslearner/utils/scheduler.py
+++ b/crosslearner/utils/scheduler.py
@@ -81,7 +81,8 @@ class GNSBatchScheduler:
             plateau_patience: Number of evaluations without improvement before
                 forcing a growth step when ``val_loss`` plateaus.
             ema: Exponential moving average factor for smoothing GNS.
-            max_global_batch: Optional cap on the absolute batch size.
+            max_global_batch: Optional cap on the absolute batch size. ``None``
+                uses the full dataset size.
         """
         self.model = model
         self.loss_fn = loss_fn
@@ -97,7 +98,11 @@ class GNSBatchScheduler:
         self.bad_evals = 0
         self.best_val = math.inf
         self.step = 0
-        self.max_B = max_global_batch
+        self.max_B = (
+            max_global_batch
+            if max_global_batch is not None
+            else len(dataloader.dataset)
+        )
         self.smoothed_gns = 0.0
         self.base_lr = [
             g["lr"] / self.loader.batch_sampler.batch_size

--- a/docs/adaptive_batch_size.rst
+++ b/docs/adaptive_batch_size.rst
@@ -32,7 +32,8 @@ Additional knobs control how aggressively the batch size grows. ``gns_band``
 sets the tolerance around ``gns_target``, ``gns_check_every`` determines how
 often the gradient noise scale is measured and ``gns_plateau_patience`` triggers
 growth when validation loss stops improving. ``gns_ema`` smooths the noise
-estimates and ``gns_max_batch`` caps the final batch size.
+estimates and ``gns_max_batch`` caps the final batch size (defaults to the
+dataset size).
 
 When to use it
 --------------

--- a/tests/test_training.py
+++ b/tests/test_training.py
@@ -534,11 +534,11 @@ def test_adaptive_batch_parameters(monkeypatch):
         gns_check_every=1,
         gns_plateau_patience=1,
         gns_ema=0.0,
-        gns_max_batch=4,
+        gns_max_batch=None,
         verbose=False,
     )
     trainer = ACXTrainer(model_cfg, cfg, device="cpu")
     monkeypatch.setattr(GNSBatchScheduler, "_grad_noise_scale", lambda self, a, b: 0.0)
     trainer.train(loader)
     assert trainer.scheduler is not None
-    assert trainer.scheduler.loader.batch_sampler.batch_size == 4
+    assert trainer.scheduler.max_B == len(loader.dataset)


### PR DESCRIPTION
## Summary
- default the adaptive batch scheduler's `max_global_batch` to the dataset size
- document the new behaviour in config and docs
- test the default behaviour

## Testing
- `ruff check .`
- `black --check .`
- `pytest --cov=crosslearner --cov-report=xml -q`


------
https://chatgpt.com/codex/tasks/task_e_685daed557cc8324a914bd49d889e0f2