### PR TITLE
Fix dropout params in sweep

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   in-place parameter updates
 - Fixed `set_seed` to skip `torch.cuda.manual_seed_all` when CUDA is unavailable
 - Added `crosslearner-sweep` command for Optuna hyperparameter search
+- Fixed dropout parameters in `crosslearner-sweep` to apply to `ModelConfig`
+  instead of `TrainingConfig`
 - Added synthetic data generation utilities with configurable noise and missing outcomes
 - MLP and ACX are now TorchScript and ONNX exportable via `export_model`
 - Added optional batch normalization through `batch_norm` flag in `ModelConfig`

--- a/crosslearner/sweep.py
+++ b/crosslearner/sweep.py
@@ -110,6 +110,9 @@ def main(argv: Iterable[str] | None = None) -> None:
             phi_layers=params["phi_layers"],
             head_layers=params["head_layers"],
             disc_layers=params["disc_layers"],
+            phi_dropout=params["phi_dropout"],
+            head_dropout=params["head_dropout"],
+            disc_dropout=params["disc_dropout"],
             batch_norm=params["batch_norm"],
         )
         train_cfg = TrainingConfig(
@@ -119,9 +122,6 @@ def main(argv: Iterable[str] | None = None) -> None:
             alpha_out=params["alpha_out"],
             beta_cons=params["beta_cons"],
             gamma_adv=params["gamma_adv"],
-            phi_dropout=params["phi_dropout"],
-            head_dropout=params["head_dropout"],
-            disc_dropout=params["disc_dropout"],
             spectral_norm=params["spectral_norm"],
             verbose=False,
         )


### PR DESCRIPTION
## Summary
- pass dropout arguments to `ModelConfig` in Optuna sweep
- document the fix in `CHANGELOG`

## Testing
- `ruff check .`
- `black --check .`
- `pytest --cov=crosslearner --cov-report=xml -q`
- `python -m crosslearner.sweep toy --trials 1 --seed 0`

------
https://chatgpt.com/codex/tasks/task_e_685dd4aaf7e083248724a36cd90fc70e