### PR TITLE
Add relativistic GAN loss

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added mixture-of-experts heads via ``moe_experts`` and ``moe_entropy_weight``
 - Baseline MLPRegressors now train until convergence
 - Added hinge and least-squares GAN losses via `adv_loss` option
+- Added relativistic GAN loss via `adv_loss='rgan'`
 - Exposed `train_acx_ensemble` in `crosslearner.training`
 - Added exponential moving average (`ema_decay`) for generator parameters
 - Added R1/R2 regularization and unrolled discriminator updates

--- a/crosslearner/sweep.py
+++ b/crosslearner/sweep.py
@@ -94,7 +94,9 @@ def _space(trial: optuna.Trial) -> dict:
         "tau_bias": trial.suggest_categorical("tau_bias", [True, False]),
         # Newly exposed training parameters
         "warm_start": trial.suggest_int("warm_start", 0, 5),
-        "adv_loss": trial.suggest_categorical("adv_loss", ["bce", "hinge", "ls"]),
+        "adv_loss": trial.suggest_categorical(
+            "adv_loss", ["bce", "hinge", "ls", "rgan"]
+        ),
         "feature_matching": trial.suggest_categorical(
             "feature_matching", [True, False]
         ),

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -47,6 +47,7 @@ the training procedure, hyperparameter sweeps and available modules.
    exponential_moving_average
    weight_clipping
    wgan_gp
+   relativistic_gan
    r1_r2_regularization
    instance_noise
    contrastive_loss

--- a/docs/relativistic_gan.rst
+++ b/docs/relativistic_gan.rst
@@ -1,0 +1,32 @@
+Relativistic GAN Loss
+=====================
+
+The ``adv_loss='rgan'`` option replaces the standard discriminator objective with
+*Relativistic Average GAN* losses. Instead of judging real and fake samples in
+isolation, the discriminator compares them directly. This often yields more
+stable gradients and encourages diverse generations.
+
+Usage
+-----
+
+Enable the loss via :class:`~crosslearner.training.TrainingConfig`::
+
+   cfg = TrainingConfig(
+       epochs=30,
+       adv_loss='rgan',
+       use_wgan_gp=True,       # optional gradient penalty
+   )
+   model = train_acx(loader, ModelConfig(p=10), cfg)
+
+When ``use_wgan_gp`` is ``True`` a gradient penalty of strength
+``lambda_gp`` is applied to the relativistic discriminator. The generator
+then maximises the probability that fake outcomes appear more realistic
+than real ones.
+
+When to use it
+--------------
+
+Relativistic adversaries can stabilise training when ordinary
+cross-entropy saturates. Try this option if the discriminator quickly
+overpowers the generator or if you observe mode collapse with the
+standard loss.

--- a/tests/test_training.py
+++ b/tests/test_training.py
@@ -335,7 +335,7 @@ def test_train_acx_batch_norm_option():
 def test_alt_adv_losses():
     loader, _ = get_toy_dataloader(batch_size=4, n=8, p=4)
     model_cfg = ModelConfig(p=4)
-    for loss in ("hinge", "lsgan"):
+    for loss in ("hinge", "lsgan", "rgan"):
         train_cfg = TrainingConfig(epochs=1, adv_loss=loss, verbose=False)
         model = train_acx(loader, model_cfg, train_cfg, device="cpu")
         assert isinstance(model, ACX)


### PR DESCRIPTION
## Summary
- implement relativistic discriminator and generator losses
- allow adv_loss='rgan' including optional gradient penalty
- document new option in docs and CHANGELOG
- extend hyperparameter sweep and training tests for rgan

## Testing
- `ruff check .`
- `black --check .`
- `pytest --cov=crosslearner --cov-report=xml -q`

------
https://chatgpt.com/codex/tasks/task_e_685df95b0da48324a441646f12ea2b6f