### PR TITLE
Log GradNorm weights

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Initial creation of CHANGELOG
 - Added `crosslearner-benchmark` command comparing ACX to baseline models
 - Added GradNorm adaptive loss balancing via ``use_gradnorm`` configuration
+- Logged GradNorm weights when ``use_gradnorm`` and ``log_grad_norms`` are enabled
 - Added PacGAN-style discriminator packing via `disc_pack` configuration
 - Unified benchmark CLI and baseline comparison
 - Added mixture-of-experts heads via ``moe_experts`` and ``moe_entropy_weight``

--- a/crosslearner/training/history.py
+++ b/crosslearner/training/history.py
@@ -20,6 +20,9 @@ class EpochStats:
     val_loss_adv: Optional[float] = None
     grad_norm_g: Optional[float] = None
     grad_norm_d: Optional[float] = None
+    w_y: Optional[float] = None
+    w_cons: Optional[float] = None
+    w_adv: Optional[float] = None
     lr_g: Optional[float] = None
     lr_d: Optional[float] = None
     gns: Optional[float] = None

--- a/crosslearner/visualization.py
+++ b/crosslearner/visualization.py
@@ -296,16 +296,34 @@ def plot_ice(
 
 
 def plot_grad_norms(history: History) -> plt.Figure:
-    """Return a matplotlib Figure with gradient norm curves."""
+    """Return a matplotlib Figure with gradient norm and weight curves."""
     epochs = [h.epoch for h in history]
-    fig, ax = plt.subplots()
+    fig, ax1 = plt.subplots()
     if any(h.grad_norm_g is not None for h in history):
-        ax.plot(epochs, [h.grad_norm_g for h in history], label="generator")
+        ax1.plot(epochs, [h.grad_norm_g for h in history], label="generator")
     if any(h.grad_norm_d is not None for h in history):
-        ax.plot(epochs, [h.grad_norm_d for h in history], label="discriminator")
-    ax.set_xlabel("epoch")
-    ax.set_ylabel("gradient norm")
-    ax.legend()
+        ax1.plot(epochs, [h.grad_norm_d for h in history], label="discriminator")
+    ax1.set_xlabel("epoch")
+    ax1.set_ylabel("gradient norm")
+
+    has_weights = any(
+        h.w_y is not None or h.w_cons is not None or h.w_adv is not None
+        for h in history
+    )
+    if has_weights:
+        ax2 = ax1.twinx()
+        if any(h.w_y is not None for h in history):
+            ax2.plot(epochs, [h.w_y for h in history], "C2--", label="w_y")
+        if any(h.w_cons is not None for h in history):
+            ax2.plot(epochs, [h.w_cons for h in history], "C3--", label="w_cons")
+        if any(h.w_adv is not None for h in history):
+            ax2.plot(epochs, [h.w_adv for h in history], "C4--", label="w_adv")
+        ax2.set_ylabel("weight")
+        lines1, labels1 = ax1.get_legend_handles_labels()
+        lines2, labels2 = ax2.get_legend_handles_labels()
+        ax2.legend(lines1 + lines2, labels1 + labels2)
+    else:
+        ax1.legend()
     fig.tight_layout()
     return fig
 

--- a/docs/gradnorm.rst
+++ b/docs/gradnorm.rst
@@ -31,6 +31,9 @@ Enable the feature via :class:`~crosslearner.training.TrainingConfig`::
 (default ``1.0``) and ``gradnorm_lr`` sets the learning rate for the internal
 weight optimiser.
 
+If ``log_grad_norms=True`` the adaptive weights are recorded in the training
+history and can be visualised with :func:`crosslearner.visualization.plot_grad_norms`.
+
 When to use it
 --------------
 

--- a/tests/test_training.py
+++ b/tests/test_training.py
@@ -587,7 +587,14 @@ def test_adaptive_batch_parameters(monkeypatch):
 def test_train_acx_gradnorm():
     loader, _ = get_toy_dataloader(batch_size=4, n=16, p=4)
     model_cfg = ModelConfig(p=4)
-    cfg = TrainingConfig(epochs=1, use_gradnorm=True, verbose=False)
+    cfg = TrainingConfig(
+        epochs=1,
+        use_gradnorm=True,
+        log_grad_norms=True,
+        return_history=True,
+        verbose=False,
+    )
     trainer = ACXTrainer(model_cfg, cfg, device="cpu")
-    trainer.train(loader)
+    model, history = trainer.train(loader)
     assert trainer.loss_weights.numel() == 3
+    assert history[0].w_y is not None

--- a/tests/test_visualization.py
+++ b/tests/test_visualization.py
@@ -166,6 +166,27 @@ def test_plot_grad_norms_returns_figure():
     matplotlib.pyplot.close(fig)
 
 
+def test_plot_grad_norms_with_weights_returns_figure():
+    hist = [
+        EpochStats(
+            epoch=0,
+            loss_d=0.0,
+            loss_g=0.0,
+            loss_y=0.0,
+            loss_cons=0.0,
+            loss_adv=0.0,
+            grad_norm_g=1.0,
+            grad_norm_d=2.0,
+            w_y=0.5,
+            w_cons=1.0,
+            w_adv=1.5,
+        )
+    ]
+    fig = plot_grad_norms(hist)
+    assert fig is not None
+    matplotlib.pyplot.close(fig)
+
+
 def test_plot_learning_rates_returns_figure():
     hist = [
         EpochStats(


### PR DESCRIPTION
## Summary
- track and average GradNorm weights during training
- output and visualize the weights alongside gradient norms
- note logging behaviour in GradNorm docs
- test GradNorm weight logging and plotting

## Testing
- `ruff check .`
- `black --check .`
- `pytest --cov=crosslearner --cov-report=xml -q`

------
https://chatgpt.com/codex/tasks/task_e_685e37dcc5288324a9489611ce1cbf96