### PR TITLE
Fix evaluation mode in ensemble predictions

### DIFF
--- a/crosslearner/evaluation/uncertainty.py
+++ b/crosslearner/evaluation/uncertainty.py
@@ -56,7 +56,11 @@ def predict_tau_ensemble(
     samples = []
     for model in models:
         device = model_device(model)
+        was_training = model.training
+        model.eval()
         _, _, _, tau = model(X.to(device))
+        if was_training:
+            model.train()
         samples.append(tau.cpu())
     stacked = torch.stack(samples)
     mean = stacked.mean(dim=0)


### PR DESCRIPTION
## Summary
- ensure that models are evaluated in `predict_tau_ensemble`

## Testing
- `ruff check .`
- `black --check .`
- `pytest --cov=crosslearner --cov-report=xml -q`

------
https://chatgpt.com/codex/tasks/task_e_685e8dbce9ec83248dd5f48727449b04