### PR TITLE
Handle GroupNorm divisibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 - Fixed `crosslearner-sweep` crash when `disentangle=True` by sampling
   `rep_dim_c`, `rep_dim_a` and `rep_dim_i`
+- Adjusted ``GroupNorm`` groups to always divide the hidden layer width,
+  preventing crashes during hyperparameter sweeps
 - Extended ``plot_losses`` to visualise validation losses and identify risk-based metrics
 - Added `get_random_dag_dataloader` for generating random DAG-based synthetic datasets
 - Initial creation of CHANGELOG

--- a/crosslearner/models/acx.py
+++ b/crosslearner/models/acx.py
@@ -3,6 +3,7 @@
 import torch
 import torch.nn as nn
 from typing import Callable, Iterable
+import math
 
 
 def _get_activation(act: str | Callable[[], nn.Module]) -> Callable[[], nn.Module]:
@@ -55,7 +56,7 @@ def _get_norm(norm: str | None, h: int) -> nn.Module | None:
     if name == "layer":
         return nn.LayerNorm(h)
     if name == "group":
-        groups = min(8, h)
+        groups = math.gcd(h, min(8, h))
         return nn.GroupNorm(groups, h)
     raise ValueError(f"Unknown normalization '{norm}'")
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -4,7 +4,7 @@ import torch.nn as nn
 import numpy as np
 import random
 
-from crosslearner.models.acx import MLP, _get_activation
+from crosslearner.models.acx import MLP, _get_activation, _get_norm
 from crosslearner.utils import (
     set_seed,
     default_device,
@@ -57,6 +57,12 @@ def test_mlp_normalization_layers(norm, cls):
     mlp = MLP(4, 2, hidden=(3, 3), norm=norm)
     layers = [m for m in mlp.net.modules() if isinstance(m, cls)]
     assert len(layers) == 2
+
+
+def test_group_norm_groups_divide_width():
+    norm = _get_norm("group", 73)
+    assert isinstance(norm, nn.GroupNorm)
+    assert 73 % norm.num_groups == 0
 
 
 def test_set_seed_reproducibility():


### PR DESCRIPTION
## Summary
- fix GroupNorm channel divisibility in `_get_norm`
- document the fix in the changelog
- test that GroupNorm selects a valid number of groups

## Testing
- `ruff check .`
- `black --check .`
- `pytest --cov=crosslearner --cov-report=xml -q`

------
https://chatgpt.com/codex/tasks/task_e_685f27c98a748324a0ce305a53579762