### PR TITLE
Fix gradient reversal packing bug

### DIFF
--- a/crosslearner/training/trainer.py
+++ b/crosslearner/training/trainer.py
@@ -1123,7 +1123,10 @@ class ACXTrainer:
                 gr_h = grad_reverse(hb, cfg.grl_weight)
                 h_p, y_p, t_p = self._pack_inputs(gr_h, Yb, Tb)
                 t_logits = model.discriminator(h_p, y_p, t_p)
-                loss_grl = bce(t_logits, Tb)
+                t_target = t_p
+                if t_target.size() != t_logits.size():
+                    t_target = t_target.mean(1, keepdim=True)
+                loss_grl = bce(t_logits, t_target)
                 loss_g += loss_grl
 
             opt_g.zero_grad(set_to_none=True)

--- a/tests/test_training.py
+++ b/tests/test_training.py
@@ -162,6 +162,14 @@ def test_train_acx_custom_architecture():
     assert isinstance(model, ACX)
 
 
+def test_train_acx_grl_disc_pack():
+    loader, _ = get_toy_dataloader(batch_size=8, n=32, p=3)
+    model_cfg = ModelConfig(p=3, disc_pack=2)
+    train_cfg = TrainingConfig(epochs=1, gradient_reversal=True, verbose=False)
+    model = train_acx(loader, model_cfg, train_cfg, device="cpu")
+    assert isinstance(model, ACX)
+
+
 def test_train_acx_custom_optimizer():
     loader, _ = get_toy_dataloader(batch_size=8, n=32, p=3)
     model_cfg = ModelConfig(p=3)


### PR DESCRIPTION
## Summary
- fix dimension mismatch when using gradient reversal with discriminator packing
- add regression test covering packed gradient reversal

## Testing
- `ruff check .`
- `black --check .`
- `pytest --cov=crosslearner --cov-report=xml -q`


------
https://chatgpt.com/codex/tasks/task_e_685f4369b2e48324a067db6eebbd3729