### PR TITLE
Fix error when running crosslearner-sweep with zero trials

### DIFF
--- a/crosslearner/sweep.py
+++ b/crosslearner/sweep.py
@@ -174,6 +174,9 @@ def main(argv: Iterable[str] | None = None) -> None:
         return evaluate_dr(model, X, T_all, Y_all, propensity)
 
     study = optuna.create_study(direction="minimize")
+    if args.trials < 1:
+        print("No trials executed")
+        return
     study.optimize(objective, n_trials=args.trials)
     print("Best value", study.best_value)
     print("Best params", study.best_params)


### PR DESCRIPTION
## Summary
- avoid crash in `crosslearner-sweep` when `--trials 0`

## Testing
- `ruff check .`
- `black --check .`
- `pytest --cov=crosslearner --cov-report=xml -q`

------
https://chatgpt.com/codex/tasks/task_e_685f4c69db848324b933d197bbac8b43