### PR TITLE
Fix sweep tau_heads constraint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   configuration options
 - Adjusted ``GroupNorm`` groups to always divide the hidden layer width,
   preventing crashes during hyperparameter sweeps
+- Enforced ``tau_heads > 1`` when ``epistemic_consistency`` is enabled in
+  ``crosslearner-sweep`` to avoid invalid trials
 - Extended ``plot_losses`` to visualise validation losses and identify risk-based metrics
 - Standardised covariates in the ``Jobs`` dataloader
 - Added `get_random_dag_dataloader` for generating random DAG-based synthetic datasets

--- a/crosslearner/sweep.py
+++ b/crosslearner/sweep.py
@@ -70,6 +70,11 @@ def _space(trial: optuna.Trial) -> dict:
     disc_layers = trial.suggest_int("disc_layers", 1, 3)
     disc_layers = [disc_width] * disc_layers
 
+    epistemic_consistency = trial.suggest_categorical(
+        "epistemic_consistency", [True, False]
+    )
+    tau_heads = trial.suggest_int("tau_heads", 2 if epistemic_consistency else 1, 4)
+
     params = {
         "rep_dim": rep_dim,
         "phi_layers": phi_layers,
@@ -98,7 +103,7 @@ def _space(trial: optuna.Trial) -> dict:
         "disc_residual": trial.suggest_categorical("disc_residual", [True, False]),
         "disc_pack": trial.suggest_int("disc_pack", 1, 4),
         "moe_experts": trial.suggest_int("moe_experts", 1, 4),
-        "tau_heads": trial.suggest_int("tau_heads", 1, 4),
+        "tau_heads": tau_heads,
         "tau_bias": trial.suggest_categorical("tau_bias", [True, False]),
         # Newly exposed training parameters
         "warm_start": trial.suggest_int("warm_start", 0, 5),
@@ -141,9 +146,7 @@ def _space(trial: optuna.Trial) -> dict:
         "disentangle": trial.suggest_categorical("disentangle", [True, False]),
         "adv_t_weight": trial.suggest_float("adv_t_weight", 0.0, 1.0),
         "adv_y_weight": trial.suggest_float("adv_y_weight", 0.0, 1.0),
-        "epistemic_consistency": trial.suggest_categorical(
-            "epistemic_consistency", [True, False]
-        ),
+        "epistemic_consistency": epistemic_consistency,
         "rep_consistency_weight": trial.suggest_float(
             "rep_consistency_weight", 0.0, 1.0
         ),

--- a/tests/test_sweep.py
+++ b/tests/test_sweep.py
@@ -38,3 +38,9 @@ def test_space_includes_new_params():
     params = _space(DummyTrial())
     assert "phi_residual" in params
     assert "pretrain_epochs" in params
+
+
+def test_epistemic_consistency_enforces_tau_heads():
+    params = _space(DummyTrial())
+    if params["epistemic_consistency"]:
+        assert params["tau_heads"] > 1


### PR DESCRIPTION
## Summary
- enforce tau_heads>1 when epistemic_consistency=True in sweep
- test that tau_heads is adjusted accordingly
- note change in changelog

## Testing
- `ruff check .`
- `black --check .`
- `pytest --cov=crosslearner --cov-report=xml -q`


------
https://chatgpt.com/codex/tasks/task_e_68605a454b688324a790e62edca4d397