### PR TITLE
Standardise outcome in Jobs dataloader

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Enforced ``tau_heads > 1`` when ``epistemic_consistency`` is enabled in
   ``crosslearner-sweep`` to avoid invalid trials
 - Extended ``plot_losses`` to visualise validation losses and identify risk-based metrics
-- Standardised covariates in the ``Jobs`` dataloader
+- Standardised covariates and outcome in the ``Jobs`` dataloader
 - Added `get_random_dag_dataloader` for generating random DAG-based synthetic datasets
 - Stopped `GNSBatchScheduler` from evaluating gradient noise once the maximum
   batch size is reached

--- a/crosslearner/datasets/jobs.py
+++ b/crosslearner/datasets/jobs.py
@@ -13,6 +13,8 @@ def get_jobs_dataloader(batch_size: int = 256):
 
     Returns:
         Loader and ``(None, None)`` because counterfactuals are unavailable.
+        The covariates and outcome are standardised to zero mean and unit
+        variance.
     """
     df = nsw_mixtape.load_pandas().data
     y = torch.tensor(df["re78"].values, dtype=torch.float32).unsqueeze(-1)
@@ -23,5 +25,8 @@ def get_jobs_dataloader(batch_size: int = 256):
     mean = x.mean(0, keepdim=True)
     std = x.std(0, unbiased=False, keepdim=True).clamp_min(1e-6)
     x = (x - mean) / std
+    y_mean = y.mean(0, keepdim=True)
+    y_std = y.std(0, unbiased=False, keepdim=True).clamp_min(1e-6)
+    y = (y - y_mean) / y_std
     loader = DataLoader(TensorDataset(x, t, y), batch_size=batch_size, shuffle=True)
     return loader, (None, None)

--- a/docs/datasets.rst
+++ b/docs/datasets.rst
@@ -40,7 +40,8 @@ The loaders cover both synthetic benchmarks and popular real-world datasets.
   Semi-synthetic Infant Health and Development Program benchmark with 100
   replications.
 ``get_jobs_dataloader``
-  Jobs training dataset (NSW study) used for off-policy evaluation.
+  Jobs training dataset (NSW study) used for off-policy evaluation. The
+  covariates and outcome are standardised.
 ``get_acic2016_dataloader`` / ``get_acic2018_dataloader``
   Load the ACIC challenge benchmarks.  The loaders automatically download the
   ``.npz`` files if they are not present locally.

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -47,6 +47,11 @@ def test_jobs_dataloader_standardization():
     std = X_all.std(0, unbiased=False)
     assert torch.allclose(mean, torch.zeros_like(mean), atol=1e-4)
     assert torch.allclose(std, torch.ones_like(std), atol=1e-4)
+    Y_all = torch.cat([b[2] for b in loader])
+    y_mean = Y_all.mean(0)
+    y_std = Y_all.std(0, unbiased=False)
+    assert torch.allclose(y_mean, torch.zeros_like(y_mean), atol=1e-4)
+    assert torch.allclose(y_std, torch.ones_like(y_std), atol=1e-4)
 
 
 def test_get_ihdp_dataloader_shapes(monkeypatch, tmp_path):


### PR DESCRIPTION
## Summary
- normalise outcomes in `get_jobs_dataloader`
- document standardisation in dataset docs and changelog
- test that outcomes are standardised

## Testing
- `ruff check .`
- `black --check .`
- `pytest --cov=crosslearner --cov-report=xml -q`

------
https://chatgpt.com/codex/tasks/task_e_686096b12a3c8324b9d8d2b8c4c2e50e