### PR TITLE
Expose batch_size as sweep hyperparameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `get_random_dag_dataloader` for generating random DAG-based synthetic datasets
 - Stopped `GNSBatchScheduler` from evaluating gradient noise once the maximum
   batch size is reached
+- `crosslearner-sweep` now optimises the training `batch_size` within the
+  dataset size
 - Initial creation of CHANGELOG
 - Added `crosslearner-benchmark` command comparing ACX to baseline models
 - Added GradNorm adaptive loss balancing via ``use_gradnorm`` configuration

--- a/tests/test_sweep.py
+++ b/tests/test_sweep.py
@@ -29,18 +29,23 @@ class DummyTrial(optuna.trial.Trial):
 
 
 def test_space_disentangle_includes_rep_dims():
-    params = _space(DummyTrial())
+    params = _space(DummyTrial(), dataset_size=128)
     assert params["disentangle"]
     assert all(k in params for k in ("rep_dim_c", "rep_dim_a", "rep_dim_i"))
 
 
 def test_space_includes_new_params():
-    params = _space(DummyTrial())
+    params = _space(DummyTrial(), dataset_size=128)
     assert "phi_residual" in params
     assert "pretrain_epochs" in params
 
 
 def test_epistemic_consistency_enforces_tau_heads():
-    params = _space(DummyTrial())
+    params = _space(DummyTrial(), dataset_size=128)
     if params["epistemic_consistency"]:
         assert params["tau_heads"] > 1
+
+
+def test_batch_size_in_bounds():
+    params = _space(DummyTrial(), dataset_size=100)
+    assert 1 <= params["batch_size"] <= 100


### PR DESCRIPTION
## Summary
- update `crosslearner-sweep` to sample `batch_size` for each trial
- add tests for the new hyperparameter
- note sweep batch size tuning in `CHANGELOG`

## Testing
- `ruff check .`
- `black --check .`
- `pytest --cov=crosslearner --cov-report=xml -q`

------
https://chatgpt.com/codex/tasks/task_e_6860a27c40c483248ac2f37513666814