### PR TITLE
Add causaldata dataloaders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Standardised covariates and outcome in the ``Jobs`` dataloader
 - Twins and ACIC 2016 datasets now load from ``causaldata`` and ``causallib``
   packages for reproducible access
+- Added loaders for several ``causaldata`` tables, including ``cps_mixtape``,
+  ``thornton_hiv``, ``nhefs_complete``, ``social_insure``, ``credit_cards`` and
+  ``close_elections_lmb``
 - Added `get_random_dag_dataloader` for generating random DAG-based synthetic datasets
 - Stopped `GNSBatchScheduler` from evaluating gradient noise once the maximum
   batch size is reached

--- a/crosslearner/datasets/__init__.py
+++ b/crosslearner/datasets/__init__.py
@@ -51,6 +51,48 @@ def get_lalonde_dataloader(*args, **kwargs):
     return _loader(*args, **kwargs)
 
 
+def get_cps_mixtape_dataloader(*args, **kwargs):
+    """Load the CPS Mixtape dataset on demand."""
+    from .cps import get_cps_mixtape_dataloader as _loader
+
+    return _loader(*args, **kwargs)
+
+
+def get_thornton_hiv_dataloader(*args, **kwargs):
+    """Load the Thornton HIV dataset on demand."""
+    from .thornton import get_thornton_hiv_dataloader as _loader
+
+    return _loader(*args, **kwargs)
+
+
+def get_nhefs_dataloader(*args, **kwargs):
+    """Load the NHEFS dataset on demand."""
+    from .nhefs import get_nhefs_dataloader as _loader
+
+    return _loader(*args, **kwargs)
+
+
+def get_social_insure_dataloader(*args, **kwargs):
+    """Load the Social Insure dataset on demand."""
+    from .social_insure import get_social_insure_dataloader as _loader
+
+    return _loader(*args, **kwargs)
+
+
+def get_credit_cards_dataloader(*args, **kwargs):
+    """Load the credit cards dataset on demand."""
+    from .credit_cards import get_credit_cards_dataloader as _loader
+
+    return _loader(*args, **kwargs)
+
+
+def get_close_elections_dataloader(*args, **kwargs):
+    """Load the close elections dataset on demand."""
+    from .close_elections import get_close_elections_dataloader as _loader
+
+    return _loader(*args, **kwargs)
+
+
 __all__ = [
     "get_toy_dataloader",
     "get_complex_dataloader",
@@ -60,6 +102,12 @@ __all__ = [
     "get_acic2018_dataloader",
     "get_twins_dataloader",
     "get_lalonde_dataloader",
+    "get_cps_mixtape_dataloader",
+    "get_thornton_hiv_dataloader",
+    "get_nhefs_dataloader",
+    "get_social_insure_dataloader",
+    "get_credit_cards_dataloader",
+    "get_close_elections_dataloader",
     "get_confounding_dataloader",
     "get_aircraft_dataloader",
     "get_tricky_dataloader",

--- a/crosslearner/datasets/close_elections.py
+++ b/crosslearner/datasets/close_elections.py
@@ -1,0 +1,18 @@
+"""Loader for the Close Elections panel data."""
+
+from causaldata import close_elections_lmb
+
+from .utils import dataframe_to_dataloader
+
+
+def get_close_elections_dataloader(batch_size: int = 256):
+    """Return dataloader for the close US House elections study."""
+    df = close_elections_lmb.load_pandas().data
+    loader = dataframe_to_dataloader(
+        df,
+        treatment_col="democrat",
+        outcome_col="score",
+        batch_size=batch_size,
+        drop=["state"],
+    )
+    return loader, (None, None)

--- a/crosslearner/datasets/cps.py
+++ b/crosslearner/datasets/cps.py
@@ -1,0 +1,18 @@
+"""Loader for the CPS Mixtape dataset."""
+
+from causaldata import cps_mixtape
+
+from .utils import dataframe_to_dataloader
+
+
+def get_cps_mixtape_dataloader(batch_size: int = 256):
+    """Return dataloader for the observational CPS sample."""
+    df = cps_mixtape.load_pandas().data
+    loader = dataframe_to_dataloader(
+        df,
+        treatment_col="treat",
+        outcome_col="re78",
+        batch_size=batch_size,
+        drop=["data_id"],
+    )
+    return loader, (None, None)

--- a/crosslearner/datasets/credit_cards.py
+++ b/crosslearner/datasets/credit_cards.py
@@ -1,0 +1,17 @@
+"""Loader for the credit card delinquency dataset."""
+
+from causaldata import credit_cards
+
+from .utils import dataframe_to_dataloader
+
+
+def get_credit_cards_dataloader(batch_size: int = 256):
+    """Return dataloader for the credit card late-payment data."""
+    df = credit_cards.load_pandas().data
+    loader = dataframe_to_dataloader(
+        df,
+        treatment_col="LateApril",
+        outcome_col="LateSept",
+        batch_size=batch_size,
+    )
+    return loader, (None, None)

--- a/crosslearner/datasets/nhefs.py
+++ b/crosslearner/datasets/nhefs.py
@@ -1,0 +1,21 @@
+"""Loader for the NHEFS smoking cessation dataset."""
+
+from causaldata import nhefs_complete
+
+from .utils import dataframe_to_dataloader
+
+
+def get_nhefs_dataloader(batch_size: int = 256):
+    """Return dataloader for the full NHEFS data."""
+    df = nhefs_complete.load_pandas().data
+    for col in df.select_dtypes(["category"]).columns:
+        df[col] = df[col].cat.codes
+    df = df.fillna(0)
+    loader = dataframe_to_dataloader(
+        df,
+        treatment_col="qsmk",
+        outcome_col="wt82_71",
+        batch_size=batch_size,
+        drop=["seqn"],
+    )
+    return loader, (None, None)

--- a/crosslearner/datasets/social_insure.py
+++ b/crosslearner/datasets/social_insure.py
@@ -1,0 +1,19 @@
+"""Loader for the Social Insure network experiment."""
+
+from causaldata import social_insure
+
+from .utils import dataframe_to_dataloader
+
+
+def get_social_insure_dataloader(batch_size: int = 256):
+    """Return dataloader for the Social Insure dataset."""
+    df = social_insure.load_pandas().data
+    df["any"] = (df["intensive"] == 1) | (df["default"] == 1)
+    loader = dataframe_to_dataloader(
+        df,
+        treatment_col="any",
+        outcome_col="takeup_survey",
+        batch_size=batch_size,
+        drop=["address", "village", "intensive", "default"],
+    )
+    return loader, (None, None)

--- a/crosslearner/datasets/thornton.py
+++ b/crosslearner/datasets/thornton.py
@@ -1,0 +1,17 @@
+"""Loader for the Thornton HIV cash-incentive study."""
+
+from causaldata import thornton_hiv
+
+from .utils import dataframe_to_dataloader
+
+
+def get_thornton_hiv_dataloader(batch_size: int = 256):
+    """Return dataloader for the Thornton HIV experiment."""
+    df = thornton_hiv.load_pandas().data.fillna(0)
+    loader = dataframe_to_dataloader(
+        df,
+        treatment_col="any",
+        outcome_col="got",
+        batch_size=batch_size,
+    )
+    return loader, (None, None)

--- a/crosslearner/datasets/utils.py
+++ b/crosslearner/datasets/utils.py
@@ -1,7 +1,12 @@
-"""Helper functions for downloading datasets."""
+"""Helper functions for downloading datasets and preparing dataloaders."""
 
 import os
 import urllib.request
+from typing import Iterable
+
+import pandas as pd
+import torch
+from torch.utils.data import DataLoader, TensorDataset
 
 
 def download_if_missing(url: str, path: str) -> str:
@@ -27,3 +32,39 @@ def download_if_missing(url: str, path: str) -> str:
             f"Please download the file manually and place it at {path}."
         ) from exc
     return path
+
+
+def dataframe_to_dataloader(
+    df: pd.DataFrame,
+    treatment_col: str,
+    outcome_col: str,
+    batch_size: int = 256,
+    drop: Iterable[str] | None = None,
+) -> DataLoader:
+    """Convert a ``pandas`` table to a ``DataLoader``.
+
+    Categorical columns are one-hot encoded and missing values imputed with 0.
+
+    Args:
+        df: Data table with treatment and outcome columns.
+        treatment_col: Column indicating treatment assignment.
+        outcome_col: Observed outcome column.
+        batch_size: Mini-batch size for the returned loader.
+        drop: Additional columns to exclude from the covariates.
+
+    Returns:
+        Loader yielding ``(X, T, Y)`` tuples.
+    """
+
+    drop = list(drop or [])
+    X = df.drop(columns=[treatment_col, outcome_col, *drop])
+    X = pd.get_dummies(X).fillna(0.0)
+    T = torch.tensor(
+        df[treatment_col].astype(float).values, dtype=torch.float32
+    ).unsqueeze(-1)
+    Y = torch.tensor(
+        df[outcome_col].astype(float).values, dtype=torch.float32
+    ).unsqueeze(-1)
+    X_t = torch.tensor(X.values, dtype=torch.float32)
+    dset = TensorDataset(X_t, T, Y)
+    return DataLoader(dset, batch_size=batch_size, shuffle=True)

--- a/docs/datasets.rst
+++ b/docs/datasets.rst
@@ -21,6 +21,12 @@ Available loaders
    crosslearner.datasets.get_acic2018_dataloader
    crosslearner.datasets.get_twins_dataloader
    crosslearner.datasets.get_lalonde_dataloader
+   crosslearner.datasets.get_cps_mixtape_dataloader
+   crosslearner.datasets.get_thornton_hiv_dataloader
+   crosslearner.datasets.get_nhefs_dataloader
+   crosslearner.datasets.get_social_insure_dataloader
+   crosslearner.datasets.get_credit_cards_dataloader
+   crosslearner.datasets.get_close_elections_dataloader
    crosslearner.datasets.get_aircraft_dataloader
    crosslearner.datasets.get_tricky_dataloader
 
@@ -50,7 +56,88 @@ The loaders cover both synthetic benchmarks and popular real-world datasets.
   observed counterfactuals.
 ``get_lalonde_dataloader``
   Original LaLonde dataset with only the ATE available.
+``get_cps_mixtape_dataloader``
+  Observational CPS data mirroring the NSW job-training study.
+``get_thornton_hiv_dataloader``
+  HIV cash-incentive RCT with binary test collection outcome.
+``get_nhefs_dataloader``
+  Health follow-up study evaluating the effect of quitting smoking.
+``get_social_insure_dataloader``
+  Network experiment dataset examining insurance uptake.
+``get_credit_cards_dataloader``
+  Large-scale credit card delinquency records for temporal causal tests.
+``get_close_elections_dataloader``
+  Panel of close US House elections for regression-discontinuity analyses.
 ``get_aircraft_dataloader``
   Simulated aircraft performance data based on the Breguet range equation.
 ``get_tricky_dataloader``
   Small imbalanced synthetic dataset designed to highlight discriminator tricks.
+
+Real datasets from ``causaldata``
+-------------------------------
+
+The `causaldata` package exposes several tabular datasets that pair a clear
+treatment indicator with a suitable outcome. They make convenient benchmarks for
+X-learners.  The table below summarises the most relevant options.
+
+.. list-table:: Causaldata quick reference
+   :header-rows: 1
+   :widths: 15 6 28 22 14 40
+
+   * - Dataset
+     - N
+     - Treatment variable(s)
+     - Outcome of interest
+     - Balance (T:C)
+     - Notes on suitability
+   * - ``nsw_mixtape``
+     - 445
+     - ``treat`` (job-training)
+     - ``re78`` earnings (continuous)
+     - 185 : 260 (≈42 % treated)
+     - Classic LaLonde RCT; moderate covariate set; clean ground-truth ATE lets you check if X-Learner can recover experimental TE
+   * - ``cps_mixtape``
+     - 15 992
+     - ``treat`` (self-selected into NSW programme)
+     - ``re78`` earnings
+     - 297 : 15 695 (≈2 % treated)
+     - Real-world selection bias and extreme class-imbalance—exactly the regime where X-Learner is theoretically strongest
+   * - ``thornton_hiv``
+     - 4 820
+     - ``any`` (received any cash incentive) or multi-level ``tinc``
+     - ``got`` (collected test result, binary) or ``hiv2004`` (status)
+     - 1 940 : 2 880 (≈40 % treated)
+     - Large RCT with simple structure; easy to binarise incentive; nice for heterogeneous-effect diagnostics
+   * - ``nhefs`` / ``nhefs_complete``
+     - 1 629 (complete)
+     - ``qsmk`` (quit smoking 1971-82)
+     - ``wt82_71`` weight change (continuous)
+     - 248 : 1 381 (≈15 % treated)
+     - Observational health data with many confounders; good stress-test for propensity modelling in Stage 1
+   * - ``social_insure``
+     - 1 410
+     - ``any`` (received any info/peer intervention)
+     - ``takeup_survey`` etc. (binary)
+     - ~50 % treated
+     - Network-experiment; covariates include village-level and demographics—useful for testing effect heterogeneity in sparse, mid-sized data
+   * - ``credit_cards``
+     - 30 000
+     - Use ``LateApril`` (late payment in Apr 2005) as “treatment” for predicting ``LateSept``
+     - ``LateSept`` (binary)
+     - 5 756 : 24 244 (≈19 % treated)
+     - A temporal-ordering causal proxy; huge, purely tabular; handy for scalability & calibration checks
+   * - ``close_elections_lmb``
+     - 13 588
+     - ``dwin`` (Democrat wins)
+     - policy outcomes
+     - ≈50 %
+     - Regression-discontinuity panel—valuable if you want to see how X-Learner behaves when RD assumptions are ignored, but requires careful feature engineering
+
+Recommended test set
+~~~~~~~~~~~~~~~~~~~~
+
+#. Fast smoke test: ``nsw_mixtape`` – small, clean binary treatment, continuous outcome.
+#. Imbalance stress test: ``cps_mixtape`` – same variables as NSW but extreme 2 % treated share.
+#. Larger RCT: ``thornton_hiv`` – lets you check variance-reduction and subgroup CATE accuracy.
+#. Observational with rich confounding: ``nhefs_complete`` – evaluates full causal pipeline.
+#. Add ``social_insure`` for mid-sized network context, and ``credit_cards`` for high-volume tabular evaluation.

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -6,7 +6,20 @@ from crosslearner.datasets.jobs import get_jobs_dataloader
 from crosslearner.datasets.aircraft import get_aircraft_dataloader
 from crosslearner.datasets.tricks import get_tricky_dataloader
 from crosslearner.datasets.random_dag import get_random_dag_dataloader
-from crosslearner.datasets import ihdp, acic2016, acic2018, twins, lalonde, synthetic
+from crosslearner.datasets import (
+    ihdp,
+    acic2016,
+    acic2018,
+    twins,
+    lalonde,
+    synthetic,
+    cps,
+    thornton,
+    nhefs,
+    social_insure,
+    credit_cards,
+    close_elections,
+)
 
 
 def test_get_toy_dataloader_shapes():
@@ -222,3 +235,51 @@ def test_get_random_dag_dataloader():
     assert Y.shape == (2, 1)
     assert mu0.shape == (4, 1)
     assert mu1.shape == (4, 1)
+
+
+def test_get_cps_mixtape_dataloader():
+    loader, _ = cps.get_cps_mixtape_dataloader(batch_size=4)
+    X, T, Y = next(iter(loader))
+    assert X.shape[0] == 4
+    assert T.shape == (4, 1)
+    assert Y.shape == (4, 1)
+
+
+def test_get_thornton_hiv_dataloader():
+    loader, _ = thornton.get_thornton_hiv_dataloader(batch_size=4)
+    X, T, Y = next(iter(loader))
+    assert X.shape[0] == 4
+    assert T.shape == (4, 1)
+    assert Y.shape == (4, 1)
+
+
+def test_get_nhefs_dataloader():
+    loader, _ = nhefs.get_nhefs_dataloader(batch_size=4)
+    X, T, Y = next(iter(loader))
+    assert X.shape[0] == 4
+    assert T.shape == (4, 1)
+    assert Y.shape == (4, 1)
+
+
+def test_get_social_insure_dataloader():
+    loader, _ = social_insure.get_social_insure_dataloader(batch_size=4)
+    X, T, Y = next(iter(loader))
+    assert X.shape[0] == 4
+    assert T.shape == (4, 1)
+    assert Y.shape == (4, 1)
+
+
+def test_get_credit_cards_dataloader():
+    loader, _ = credit_cards.get_credit_cards_dataloader(batch_size=4)
+    X, T, Y = next(iter(loader))
+    assert X.shape[0] == 4
+    assert T.shape == (4, 1)
+    assert Y.shape == (4, 1)
+
+
+def test_get_close_elections_dataloader():
+    loader, _ = close_elections.get_close_elections_dataloader(batch_size=4)
+    X, T, Y = next(iter(loader))
+    assert X.shape[0] == 4
+    assert T.shape == (4, 1)
+    assert Y.shape == (4, 1)


### PR DESCRIPTION
## Summary
- add loaders for cps_mixtape, thornton_hiv, nhefs_complete, social_insure, credit_cards and close_elections_lmb datasets
- expose new helpers in `crosslearner.datasets`
- document additional loader functions
- update dataset unit tests

## Testing
- `ruff check .`
- `black --check .`
- `pytest --cov=crosslearner --cov-report=xml -q`


------
https://chatgpt.com/codex/tasks/task_e_6860f0dd7d4c8324a5a84956f386de83