### PR TITLE
Expose causaldata loaders to crosslearner-sweep

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   batch size is reached
 - `crosslearner-sweep` now optimises the training `batch_size` within the
   dataset size
+- `crosslearner-sweep` accepts the full set of ``causaldata`` loaders, including
+  ``cps_mixtape``, ``thornton_hiv``, ``nhefs_complete``, ``social_insure``,
+  ``credit_cards`` and ``close_elections_lmb``
 - Initial creation of CHANGELOG
 - Added `crosslearner-benchmark` command comparing ACX to baseline models
 - Added GradNorm adaptive loss balancing via ``use_gradnorm`` configuration

--- a/crosslearner/sweep.py
+++ b/crosslearner/sweep.py
@@ -22,6 +22,12 @@ from .datasets import (
     get_aircraft_dataloader,
     get_tricky_dataloader,
     get_random_dag_dataloader,
+    get_cps_mixtape_dataloader,
+    get_thornton_hiv_dataloader,
+    get_nhefs_dataloader,
+    get_social_insure_dataloader,
+    get_credit_cards_dataloader,
+    get_close_elections_dataloader,
 )
 from .training.train_acx import train_acx
 from .training import ModelConfig, TrainingConfig
@@ -44,6 +50,12 @@ DATASET_LOADERS: Dict[
     "aircraft": get_aircraft_dataloader,
     "tricky": get_tricky_dataloader,
     "random_dag": get_random_dag_dataloader,
+    "cps": get_cps_mixtape_dataloader,
+    "thornton_hiv": get_thornton_hiv_dataloader,
+    "nhefs": get_nhefs_dataloader,
+    "social_insure": get_social_insure_dataloader,
+    "credit_cards": get_credit_cards_dataloader,
+    "close_elections": get_close_elections_dataloader,
 }
 
 


### PR DESCRIPTION
## Summary
- support all causaldata dataloaders with `crosslearner-sweep`
- document the new dataset options in the changelog

## Testing
- `ruff check .`
- `black --check .`
- `pytest --cov=crosslearner --cov-report=xml -q`

------
https://chatgpt.com/codex/tasks/task_e_68610424ce908324ae0e5a6a94ad3b5f