### PR TITLE
Fix scheduler messages at max batch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `get_random_dag_dataloader` for generating random DAG-based synthetic datasets
 - Stopped `GNSBatchScheduler` from evaluating gradient noise once the maximum
   batch size is reached
+- Prevented spurious scheduler messages when the batch size cannot increase
 - `crosslearner-sweep` now optimises the training `batch_size` within the
   dataset size
 - `crosslearner-sweep` accepts the full set of ``causaldata`` loaders, including

--- a/crosslearner/utils/scheduler.py
+++ b/crosslearner/utils/scheduler.py
@@ -139,6 +139,8 @@ class GNSBatchScheduler:
         new_B = (
             min(old_B * self.growth, self.max_B) if self.max_B else old_B * self.growth
         )
+        if new_B <= old_B:
+            return
         self.loader.batch_sampler.batch_size = new_B
         for pg, base in zip(self.opt.param_groups, self.base_lr):
             pg["lr"] = base * new_B


### PR DESCRIPTION
## Summary
- prevent batch scheduler from printing when the batch size cannot grow
- note this fix in the changelog

## Testing
- `ruff check .`
- `black --check .`
- `pytest --cov=crosslearner --cov-report=xml -q`

------
https://chatgpt.com/codex/tasks/task_e_68610f7cc74c8324981a132be73b2a01