### PR TITLE
Fix disc_pack crash for small batches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Standardised covariates and outcome in the ``Jobs`` dataloader
 - Twins and ACIC 2016 datasets now load from ``causaldata`` and ``causallib``
   packages for reproducible access
+- Fixed ``ACXTrainer._pack_inputs`` crash when the batch size is smaller than
+  ``disc_pack``
 - Added loaders for several ``causaldata`` tables, including ``cps_mixtape``,
   ``thornton_hiv``, ``nhefs_complete``, ``social_insure``, ``credit_cards`` and
   ``close_elections_lmb``

--- a/crosslearner/training/trainer.py
+++ b/crosslearner/training/trainer.py
@@ -355,12 +355,15 @@ class ACXTrainer:
             t: Treatment tensor.
 
         Returns:
-            Packed versions of ``(h, y, t)``.
+            Packed versions of ``(h, y, t)``. If ``disc_pack`` exceeds the batch
+            size, the tensors are returned unchanged.
         """
         pack = max(1, int(self.model_cfg.disc_pack))
         if pack <= 1:
             return h, y, t
         b = (h.size(0) // pack) * pack
+        if b == 0:
+            return h, y, t
         h = h[:b].reshape(b // pack, -1)
         y = y[:b].reshape(b // pack, -1)
         t = t[:b].reshape(b // pack, -1)

--- a/tests/test_training.py
+++ b/tests/test_training.py
@@ -170,6 +170,17 @@ def test_train_acx_grl_disc_pack():
     assert isinstance(model, ACX)
 
 
+def test_pack_inputs_handles_small_batch():
+    trainer = ACXTrainer(ModelConfig(p=3, disc_pack=4), TrainingConfig(), device="cpu")
+    h = torch.randn(2, trainer.model.rep_dim)
+    y = torch.randn(2, 1)
+    t = torch.randint(0, 2, (2, 1))
+    h_p, y_p, t_p = trainer._pack_inputs(h, y, t)
+    assert h_p.shape == h.shape
+    assert y_p.shape == y.shape
+    assert t_p.shape == t.shape
+
+
 def test_train_acx_custom_optimizer():
     loader, _ = get_toy_dataloader(batch_size=8, n=32, p=3)
     model_cfg = ModelConfig(p=3)


### PR DESCRIPTION
## Summary
- handle small batches in `_pack_inputs` so `disc_pack` greater than batch size no longer crashes
- test `_pack_inputs` for tiny batches
- document fix in CHANGELOG

## Testing
- `ruff check .`
- `black --check .`
- `pytest --cov=crosslearner --cov-report=xml -q`

------
https://chatgpt.com/codex/tasks/task_e_68620026bb2483249d953892698f562e