### PR TITLE
Clamp DR propensities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ``credit_cards`` and ``close_elections_lmb``
 - ``crosslearner-sweep`` now estimates propensities via cross-validation using
   ``estimate_propensity`` instead of assuming a constant treatment probability
+- Doubly robust risk evaluation now clamps and stabilises propensities for
+  improved robustness during sweeps
 - Initial creation of CHANGELOG
 - Added `crosslearner-benchmark` command comparing ACX to baseline models
 - Added GradNorm adaptive loss balancing via ``use_gradnorm`` configuration


### PR DESCRIPTION
## Summary
- clamp propensity scores in `evaluate_dr` and compute stabilized weights
- document improved robustness in changelog

## Testing
- `ruff check .`
- `black --check .`
- `pytest --cov=crosslearner --cov-report=xml -q`

------
https://chatgpt.com/codex/tasks/task_e_6862028d40bc8324b838e907ba0ed502