### PR TITLE
Add baseline trainer using cross-fitted propensities

### DIFF
--- a/crosslearner/evaluation/propensity.py
+++ b/crosslearner/evaluation/propensity.py
@@ -8,7 +8,12 @@ from sklearn.model_selection import KFold
 
 
 def estimate_propensity(
-    X: torch.Tensor, T: torch.Tensor, *, folds: int = 5, seed: int = 0
+    X: torch.Tensor,
+    T: torch.Tensor,
+    *,
+    folds: int = 5,
+    seed: int = 0,
+    eps: float = 1e-3,
 ) -> torch.Tensor:
     """Return cross-fitted propensity scores via logistic regression.
 
@@ -31,4 +36,6 @@ def estimate_propensity(
         model.fit(X_np[train_idx], T_np[train_idx])
         pred = model.predict_proba(X_np[test_idx])[:, 1]
         prop[test_idx] = torch.tensor(pred, dtype=torch.float32)
+
+    prop = prop.clamp(min=eps, max=1 - eps)
     return prop.unsqueeze(-1)

--- a/crosslearner/training/baseline.py
+++ b/crosslearner/training/baseline.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Tuple
+
+import numpy as np
+import torch
+from sklearn.model_selection import KFold
+from sklearn.neural_network import MLPRegressor
+from torch.utils.data import DataLoader
+
+from crosslearner.evaluation.propensity import estimate_propensity
+from crosslearner.utils import set_seed
+
+
+@dataclass
+class BaselineConfig:
+    p: int
+    folds: int = 5
+    epochs: int = 1
+    lr: float = 1e-3
+    epsilon_prop: float = 1e-3
+    seed: int = 0
+
+
+def _split_indices(n: int, folds: int, seed: int) -> Tuple[torch.Tensor, torch.Tensor]:
+    kf = KFold(n_splits=folds, shuffle=True, random_state=seed)
+    train_idx, val_idx = next(kf.split(range(n)))
+    return torch.tensor(train_idx), torch.tensor(val_idx)
+
+
+def pseudo_outcome(
+    mu0: torch.Tensor,
+    mu1: torch.Tensor,
+    T: torch.Tensor,
+    Y: torch.Tensor,
+    e_hat: torch.Tensor,
+    eps: float,
+) -> torch.Tensor:
+    e = e_hat.clamp(min=eps, max=1 - eps)
+    mu = T * mu1 + (1.0 - T) * mu0
+    return mu1 - mu0 + (T - e) / (e * (1.0 - e)) * (Y - mu)
+
+
+def train_baseline(
+    loader: DataLoader,
+    mu0: torch.Tensor,
+    mu1: torch.Tensor,
+    cfg: BaselineConfig,
+    device: str = "cpu",
+) -> Tuple[MLPRegressor, list[float]]:
+    set_seed(cfg.seed)
+    device_t = torch.device(device)
+    X = torch.cat([b[0] for b in loader]).to(device_t)
+    T = torch.cat([b[1] for b in loader]).to(device_t)
+    Y = torch.cat([b[2] for b in loader]).to(device_t)
+    mu0 = mu0.to(device_t)
+    mu1 = mu1.to(device_t)
+
+    e_hat = estimate_propensity(
+        X.cpu(), T.cpu(), folds=cfg.folds, seed=cfg.seed, eps=cfg.epsilon_prop
+    )
+    e_hat = e_hat.to(device_t)
+    D = pseudo_outcome(mu0, mu1, T, Y, e_hat, cfg.epsilon_prop)
+
+    n = X.size(0)
+    train_idx, val_idx = _split_indices(n, cfg.folds, cfg.seed)
+    X_train = X[train_idx].cpu().numpy()
+    y_train = D[train_idx].cpu().numpy().ravel()
+    X_val = X[val_idx].cpu().numpy()
+    y_val = D[val_idx].cpu().numpy().ravel()
+
+    val_pred0 = np.zeros_like(y_val)
+    init_loss = float(np.sqrt(np.mean((val_pred0 - y_val) ** 2)))
+
+    model = MLPRegressor(
+        hidden_layer_sizes=(256, 128, 64),
+        max_iter=cfg.epochs,
+        random_state=cfg.seed,
+        learning_rate_init=cfg.lr,
+    )
+    model.fit(X_train, y_train)
+    val_pred = model.predict(X_val)
+    final_loss = float(np.sqrt(np.mean((val_pred - y_val) ** 2)))
+    return model, [init_loss, final_loss]

--- a/tests/test_baseline_training.py
+++ b/tests/test_baseline_training.py
@@ -1,0 +1,21 @@
+import torch
+from crosslearner.datasets.toy import get_toy_dataloader
+from crosslearner.training.baseline import BaselineConfig, train_baseline
+from crosslearner.evaluation.propensity import estimate_propensity
+
+
+def test_propensity_crossfit_deterministic():
+    loader, _ = get_toy_dataloader(batch_size=8, n=32, p=3, seed=0)
+    X = torch.cat([b[0] for b in loader])
+    T = torch.cat([b[1] for b in loader])
+    e1 = estimate_propensity(X, T, folds=3, seed=1)
+    e2 = estimate_propensity(X, T, folds=3, seed=1)
+    assert torch.allclose(e1, e2)
+
+
+def test_val_pehe_proxy_decreases():
+    loader, (mu0, mu1) = get_toy_dataloader(batch_size=8, n=64, p=3, seed=0)
+    cfg = BaselineConfig(p=3, epochs=3, seed=0)
+    _, history = train_baseline(loader, mu0, mu1, cfg)
+    assert len(history) == 2
+    assert all(isinstance(v, float) for v in history)


### PR DESCRIPTION
## Summary
- implement simple baseline trainer that cross-fits a logistic model for propensities
- clip estimated propensities
- compute doubly robust pseudo-outcomes and fit an MLP regressor
- expose new propensity clamp parameter
- test deterministic cross-fitting and baseline training output

## Testing
- `ruff check .`
- `black --check .`
- `pytest --cov=crosslearner --cov-report=xml -q`

------
https://chatgpt.com/codex/tasks/task_e_686316cbd278832496d865b57449cd04